### PR TITLE
Fixed broken ordering in outline and export

### DIFF
--- a/src/app/components/timeline/BlankCard.js
+++ b/src/app/components/timeline/BlankCard.js
@@ -40,7 +40,18 @@ class BlankCard extends Component {
     const droppedData = JSON.parse(json)
     if (!droppedData.cardId) return
 
-    this.props.actions.editCardCoordinates(droppedData.cardId, this.props.lineId, this.props.chapterId, this.props.currentTimeline)
+    const {
+      chapterId,
+      lineId,
+      isSeries
+    } = this.props;
+
+    this.props.actions.reorderCardsWithinLine(
+      chapterId,
+      lineId,
+      isSeries,
+      [droppedData.cardId],
+    )
   }
 
   saveCreate = () => {


### PR DESCRIPTION
The blank card was not handling card drops properly.
Switched to use the same action as the SceneCards
was using to move cards around

refs: BUG-70