### PR TITLE
Fix pasting rich content into RCE

### DIFF
--- a/src/common/slate_serializers/from_html.js
+++ b/src/common/slate_serializers/from_html.js
@@ -79,6 +79,7 @@ export function deserialize (el) {
     case 'A':
       return jsx('element', { type: 'link', url: el.getAttribute('href') }, children)
     default:
-      return el.textContent
+      if (children.length === 0) return el.textContent;
+      return children;
   }
 }


### PR DESCRIPTION
fixes: BUG-51

Pasting and matching style worked for me how I would expect it to. But there was a bug with pasting into the RCE and it losing its original styling which this fixes. So I'm not sure if this fixes the issue that the task was identifying but it was a bug nonetheless.

There is still an issue with slate where copying text within a mark doesn't capture the HTML for the mark itself.
https://github.com/ianstormtaylor/slate/issues/734