### PR TITLE
Bugfix drag and drop between rows in book list

### DIFF
--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -60,10 +60,12 @@ class BookList extends Component {
     const sourceRow = +source.droppableId
     const destinationRow = +destination.droppableId
     const allIds = _.flatten(this.state.rows)
+    // Maintains relative positioning at destination of drop
+    const adjustForDownwardMovement = (sourceRow < destinationRow ? -1 : 0)
     const reOrderedIds = this.reorder(
       allIds,
       source.index + sourceRow * this.state.itemsPerRow,
-      destination.index + destinationRow * this.state.itemsPerRow
+      destination.index + destinationRow * this.state.itemsPerRow + adjustForDownwardMovement
     )
     this.setState({
       rows: _.chunk(reOrderedIds, this.state.itemsPerRow)

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -29,6 +29,12 @@ class BookList extends Component {
   addBook = () => {
     const { actions, books, lineActions, sceneActions } = this.props
     const newBookId = objectId(books.allIds)
+    this.setState({
+      rows: [
+        ...this.state.rows.slice(0, this.state.rows.length - 1),
+        [...this.state.rows[this.state.rows.length - 1], newBookId]
+      ]
+    })
     actions.addBook()
     // add a plotline
     lineActions.addLine(newBookId)

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -71,7 +71,7 @@ class BookList extends Component {
     this.props.actions.reorderBooks(reOrderedIds)
   }
 
-  componentDidMount () {
+  updateLayout = () => {
     let newBookWidth
     if (this.bookRef.current) {
       const { width } = this.bookRef.current.getBoundingClientRect()
@@ -82,13 +82,28 @@ class BookList extends Component {
     }
 
     if (this.dragDropAreaRef.current) {
-      const { width } = this.dragDropAreaRef.current.getBoundingClientRect()
-      const itemsPerRow = Math.floor(width / (newBookWidth || this.state.bookWidth))
+      const { width } = this.dragDropAreaRef.current.querySelector('#book-list').getBoundingClientRect()
+      const style = window.getComputedStyle(this.dragDropAreaRef.current)
+      const leftPadding = parseInt(style.paddingLeft)
+      const rightPadding = parseInt(style.paddingRight)
+      const itemsPerRow = Math.floor(
+        (width - (leftPadding + rightPadding)) /
+        (newBookWidth || this.state.bookWidth)
+      )
       this.setState({
         rows: _.chunk(this.props.books.allIds, itemsPerRow),
         itemsPerRow
       })
     }
+  }
+
+  componentDidMount () {
+    this.updateLayout()
+    window.addEventListener('resize', this.updateLayout)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.updateLayout)
   }
 
   renderBooks (books) {
@@ -123,6 +138,7 @@ class BookList extends Component {
               {(provided, snapshot) => (
                 <div
                   ref={provided.innerRef}
+                  id='book-list'
                   className={cx('book-list__list', {dragging: snapshot.isDraggingOver})}
                   {...provided.droppableProps}
                 >

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -22,7 +22,7 @@ class BookList extends Component {
     super(props)
     this.state = {
       // Defaults based on when this was written.  Updated when the
-      // componentmounts.
+      // component mounts.
       bookWidth: 245,
       itemsPerRow: 5,
       rows: [props.books.allIds]
@@ -62,10 +62,12 @@ class BookList extends Component {
     const allIds = _.flatten(this.state.rows)
     // Maintains relative positioning at destination of drop
     const adjustForDownwardMovement = (sourceRow < destinationRow ? -1 : 0)
+    const sourceRowOffset = sourceRow * this.state.itemsPerRow
+    const destinationRowOffset = destinationRow * this.state.itemsPerRow
     const reOrderedIds = this.reorder(
       allIds,
-      source.index + sourceRow * this.state.itemsPerRow,
-      destination.index + destinationRow * this.state.itemsPerRow + adjustForDownwardMovement
+      source.index + sourceRowOffset,
+      destination.index + destinationRowOffset + adjustForDownwardMovement
     )
     this.setState({
       rows: _.chunk(reOrderedIds, this.state.itemsPerRow)
@@ -76,7 +78,10 @@ class BookList extends Component {
   updateLayout = () => {
     let newBookWidth
     if (this.bookRef.current) {
-      const { width } = this.bookRef.current.getBoundingClientRect()
+      const { width } = this
+        .bookRef
+        .current
+        .getBoundingClientRect()
       newBookWidth = width
       this.setState({
         bookWidth: width
@@ -84,7 +89,11 @@ class BookList extends Component {
     }
 
     if (this.dragDropAreaRef.current) {
-      const { width } = this.dragDropAreaRef.current.querySelector('#book-list').getBoundingClientRect()
+      const { width } = this
+        .dragDropAreaRef
+        .current
+        .querySelector('#book-list')
+        .getBoundingClientRect()
       const style = window.getComputedStyle(this.dragDropAreaRef.current)
       const leftPadding = parseInt(style.paddingLeft)
       const rightPadding = parseInt(style.paddingRight)

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -16,13 +16,15 @@ import { objectId } from '../../store/newIds'
 
 class BookList extends Component {
   dragDropAreaRef = React.createRef();
+  bookRef = React.createRef();
 
   constructor (props) {
     super(props)
     this.state = {
-      // TODO: temp, this should come from inspecting a book on the DOM
+      // Defaults based on when this was written.  Updated when the
+      // componentmounts.
       bookWidth: 245,
-      itemsPerRow: null,
+      itemsPerRow: 5,
       rows: [props.books.allIds]
     }
   }
@@ -70,9 +72,18 @@ class BookList extends Component {
   }
 
   componentDidMount () {
+    let newBookWidth
+    if (this.bookRef.current) {
+      const { width } = this.bookRef.current.getBoundingClientRect()
+      newBookWidth = width
+      this.setState({
+        bookWidth: width
+      })
+    }
+
     if (this.dragDropAreaRef.current) {
       const { width } = this.dragDropAreaRef.current.getBoundingClientRect()
-      const itemsPerRow = Math.floor(width / this.state.bookWidth)
+      const itemsPerRow = Math.floor(width / (newBookWidth || this.state.bookWidth))
       this.setState({
         rows: _.chunk(this.props.books.allIds, itemsPerRow),
         itemsPerRow
@@ -91,7 +102,11 @@ class BookList extends Component {
             style={provided.draggableProps.style}
             className={cx('book-list__droppable', {dragging: snapshot.isDragging})}
           >
-            <Book bookId={id} bookNumber={idx + 1} />
+            {id === 0 ? (
+              <Book bookId={id} bookNumber={idx + 1} ref={this.bookRef} />
+            ) : (
+              <Book bookId={id} bookNumber={idx + 1} />
+            )}
           </div>
         )}
       </Draggable>

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -15,8 +15,8 @@ import { chunk, flatten } from 'lodash'
 import { objectId } from '../../store/newIds'
 
 class BookList extends Component {
-  dragDropAreaRef = React.createRef();
-  bookRef = React.createRef();
+  dragDropAreaRef = React.createRef()
+  bookRef = React.createRef()
 
   constructor (props) {
     super(props)

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -11,7 +11,7 @@ import Book from './Book'
 import { Glyphicon } from 'react-bootstrap'
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
 import cx from 'classnames'
-import _ from 'lodash';
+import { chunk, flatten } from 'lodash'
 import { objectId } from '../../store/newIds'
 
 class BookList extends Component {
@@ -59,7 +59,7 @@ class BookList extends Component {
     const { source, destination } = result
     const sourceRow = +source.droppableId
     const destinationRow = +destination.droppableId
-    const allIds = _.flatten(this.state.rows)
+    const allIds = flatten(this.state.rows)
     // Maintains relative positioning at destination of drop
     const adjustForDownwardMovement = (sourceRow < destinationRow ? -1 : 0)
     const sourceRowOffset = sourceRow * this.state.itemsPerRow
@@ -70,7 +70,7 @@ class BookList extends Component {
       destination.index + destinationRowOffset + adjustForDownwardMovement
     )
     this.setState({
-      rows: _.chunk(reOrderedIds, this.state.itemsPerRow)
+      rows: chunk(reOrderedIds, this.state.itemsPerRow)
     })
     this.props.actions.reorderBooks(reOrderedIds)
   }
@@ -102,7 +102,7 @@ class BookList extends Component {
         (newBookWidth || this.state.bookWidth)
       )
       this.setState({
-        rows: _.chunk(this.props.books.allIds, itemsPerRow),
+        rows: chunk(this.props.books.allIds, itemsPerRow),
         itemsPerRow
       })
     }

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -28,10 +28,10 @@ class BookList extends Component {
   reorder = (startIndex, endIndex) => {
     const list = this.props.books.allIds
 
-    const [removed] = list.splice(startIndex, 1);
-    list.splice(endIndex, 0, removed);
+    const [removed] = list.splice(startIndex, 1)
+    list.splice(endIndex, 0, removed)
 
-    return list;
+    return list
   }
 
   onDragEnd = (result) => {

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -42,21 +42,33 @@ class BookList extends Component {
     sceneActions.addScene(newBookId)
   }
 
-  reorder = (startIndex, endIndex) => {
-    const list = this.props.books.allIds
+  reorder = (bookIds, startIndex, endIndex) => {
+    const [removed] = bookIds.splice(startIndex, 1)
+    bookIds.splice(endIndex, 0, removed)
 
-    const [removed] = list.splice(startIndex, 1)
-    list.splice(endIndex, 0, removed)
-
-    return list
+    return bookIds
   }
 
   onDragEnd = (result) => {
     // dropped outside the list
     if (!result.destination) return
 
-    const ids = this.reorder(result.source.index, result.destination.index)
-    this.props.actions.reorderBooks(ids)
+    const { source, destination } = result
+    const sourceRow = +source.droppableId
+    const destinationRow = +destination.droppableId
+
+    if (sourceRow === destinationRow) {
+      const reOrderedRow = this.reorder(this.state.rows[sourceRow], source.index, destination.index)
+      this.setState({
+        ...this.state.rows.slice(0, sourceRow - 1),
+        reOrderedRow,
+        ...this.state.rows.slice(sourceRow + 1)
+      })
+      const ids = Array.prototype.concat.apply(this.state.rows)
+      this.props.actions.reorderBooks(ids)
+    } else {
+      alert('todo')
+    }
   }
 
   componentDidMount () {
@@ -93,7 +105,7 @@ class BookList extends Component {
       <DragDropContext onDragEnd={this.onDragEnd}>
         {
           this.state.rows.map((row, index) => (
-            <Droppable key={index} droppableId={`droppable-${index}`} direction='horizontal'>
+            <Droppable key={index} droppableId={`${index}`} direction='horizontal'>
               {(provided, snapshot) => (
                 <div
                   ref={provided.innerRef}

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -22,6 +22,7 @@ class BookList extends Component {
     this.state = {
       // TODO: temp, this should come from inspecting a book on the DOM
       bookWidth: 245,
+      itemsPerRow: null,
       rows: [props.books.allIds]
     }
   }
@@ -56,19 +57,16 @@ class BookList extends Component {
     const { source, destination } = result
     const sourceRow = +source.droppableId
     const destinationRow = +destination.droppableId
-
-    if (sourceRow === destinationRow) {
-      const reOrderedRow = this.reorder(this.state.rows[sourceRow], source.index, destination.index)
-      this.setState({
-        ...this.state.rows.slice(0, sourceRow - 1),
-        reOrderedRow,
-        ...this.state.rows.slice(sourceRow + 1)
-      })
-      const ids = Array.prototype.concat.apply(this.state.rows)
-      this.props.actions.reorderBooks(ids)
-    } else {
-      alert('todo')
-    }
+    const allIds = _.flatten(this.state.rows)
+    const reOrderedIds = this.reorder(
+      allIds,
+      source.index + sourceRow * this.state.itemsPerRow,
+      destination.index + destinationRow * this.state.itemsPerRow
+    )
+    this.setState({
+      rows: _.chunk(reOrderedIds, this.state.itemsPerRow)
+    })
+    this.props.actions.reorderBooks(reOrderedIds)
   }
 
   componentDidMount () {
@@ -76,7 +74,8 @@ class BookList extends Component {
       const { width } = this.dragDropAreaRef.current.getBoundingClientRect()
       const itemsPerRow = Math.floor(width / this.state.bookWidth)
       this.setState({
-        rows: _.chunk(this.props.books.allIds, itemsPerRow)
+        rows: _.chunk(this.props.books.allIds, itemsPerRow),
+        itemsPerRow
       })
     }
   }

--- a/src/css/book.scss
+++ b/src/css/book.scss
@@ -28,10 +28,9 @@
 
 .book-list__list {
   display: flex;
-  flex-wrap: wrap;
-  overflow: auto;
   padding: 40px 5px;
   padding-top: 0;
+  overflow: hidden;
 
   &.dragging {
     background-color: rgba(218, 226, 236, 0.2); // $gray-8 with alpha


### PR DESCRIPTION
# BufFix: Dragging Between Rows in Book List

Fixes problem where books couldn't be dragged between rows of books in the BookList.

## Problem Description

When there are enough books, the display wraps books which don't fit on a single line onto the next.  `react-beautiful-dnd` is designed to handle a single row or column and fails to meet our need of dragging books in a flex-grid layout.

This problem is documented on Github: (https://github.com/atlassian/react-beautiful-dnd/issues/316).
There is mention of a plan to fix it, but, for the interim, a workaround is required.

## Alternatives

Other libraries exist which handle our use case.

### React Grid DnD

This is a good alternative and is worth considering as an alternative to this PR https://www.npmjs.com/package/react-grid-dnd.  I've used the library before and can confirm that it works for our use case.

### Use Multiple Droppables

As documented in `react-beautiful-dnd`'s docs, there's a way to transfer items between Droppables in the same DragAndDropContext.  (See https://github.com/atlassian/react-beautiful-dnd/blob/master/docs/about/examples.md, https://codesandbox.io/s/-w5szl?file=/src/index.js).

This sample requires minor modifications and rebalancing between droppable areas to create the effect that there is one contiguous area.

### Others

Other developers report https://github.com/clauderic/dnd-kit and https://github.com/clauderic/react-sortable-hoc.

## Decision

I opted for Multiple Droppables because `react-beautiful-dnd` does what it says on the tin.  It's animations, features and look & feel are the better than React Grid DnD was when I used it.  It also appeared to be a simpler path than ripping out the existing work (I might be wrong here!)

## Implementation Considerations

### State

I used state on the BookList component because the fact that there are rows, the size of books and the number of books per row can be safely encapsulated without impacting the Redux store.  The purist side of me says that it should be in the store, but there should be no issues whatsoever reproducing the visual state of the UI from the store without including these pieces of state there.

### Resizing

I've hooked a method to update layout into the `resize` event so that Droppables are created dynamically and as needed when the window changes size.

When the component mounts, two refs are inspected to find out the size of books and the width of the DnD area.  This is potentially brittle because it relies on a DOM query to find the book with ID 0.

### Layout

When books are dragged downwards they leave behind a temporary gap in the source row.  This leads to a minor glitch from the users perspective when the layout updates because the first book in the destination row must move back up to the previous row.  The change only happens when the user drops the book so it might be a bit jolting for their experience.

## Testing

I tested the feature manually because I couldn't find many tests.  Is there a convention for tests or is this something that's open for design/discussion?