### PR TITLE
Fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pack": "NODE_ENV=production node_modules/.bin/webpack",
     "pack:windows": "node_modules\\.bin\\webpack",
     "dist": "node build/initEnv.js && npm run pack && electron-builder -ml",
-    "dist:windows": "node build/initEnv.js && npm run pack:windows && electron-builder",
+    "dist:windows": "node build/initEnv.js && npm run pack:windows && electron-builder -w",
     "dist:all": "npm run pack && electron-builder -mw",
     "extract-strings": "format-message extract -o locales/en.json \"bin/**/*.js\" \"src/**/*.js\" \"shared/**/*.js\" && npm run generate-flipped",
     "generate-flipped": "node ./locales/build-flipped-locale.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const sourceMapsPath = path.resolve(__dirname, '..', '..', 'pltr_sourcemaps', pa
 
 var plugins = [
   new webpack.IgnorePlugin(/main/, /bin/),
-  new webpack.DefinePlugin({'__REACT_DEVTOOLS_GLOBAL_HOOK__': '({ isDisabled: true })'}),
+  new webpack.DefinePlugin({ __REACT_DEVTOOLS_GLOBAL_HOOK__: '({ isDisabled: true })' }),
 ]
 
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
@@ -15,12 +15,14 @@ var plugins = [
 // }
 
 if (process.env.NODE_ENV !== 'dev') {
-  plugins.push(new webpack.DefinePlugin({'process.env.NODE_ENV': JSON.stringify('production')}))
+  plugins.push(new webpack.DefinePlugin({ 'process.env.NODE_ENV': JSON.stringify('production') }))
   plugins.push(new webpack.IgnorePlugin(/regenerator|nodent|js\-beautify/, /ajv/))
-  plugins.push(new webpack.SourceMapDevToolPlugin({
-    append: `\n//# sourceMappingURL=https://raw.githubusercontent.com/Plotinator/pltr_sourcemaps/main/${packageJSON.version}/[url]`,
-    filename: '[name].map',
-  }))
+  plugins.push(
+    new webpack.SourceMapDevToolPlugin({
+      append: `\n//# sourceMappingURL=https://raw.githubusercontent.com/Plotinator/pltr_sourcemaps/main/${packageJSON.version}/[url]`,
+      filename: '[name].map',
+    })
+  )
 }
 
 module.exports = {
@@ -34,28 +36,32 @@ module.exports = {
   },
   output: {
     path: isForMaps ? sourceMapsPath : path.resolve(__dirname, 'bin'),
-    filename: '[name].bundle.js'
+    filename: '[name].bundle.js',
   },
   module: {
-    rules: [{
-      test: /\.js$/,
-      loader: 'babel-loader',
-      include: path.resolve(__dirname, 'src'),
-      exclude: /node_modules/,
-      query: {
-        cacheDirectory: true,
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        include: path.resolve(__dirname, 'src'),
+        exclude: /node_modules/,
+        query: {
+          cacheDirectory: true,
+        },
       },
-    }, {
-      test: /\.scss$/,
-      loader: 'sass-loader',
-      include: path.resolve(__dirname, 'src', 'css'),
-    }, {
-      test: /\.(png|jpg|gif)$/,
-      loader: 'url-loader',
-      query: {
-        limit: 1048576,
+      {
+        test: /\.scss$/,
+        loader: 'sass-loader',
+        include: path.resolve(__dirname, 'src', 'css'),
       },
-    }]
+      {
+        test: /\.(png|jpg|gif)$/,
+        loader: 'url-loader',
+        query: {
+          limit: 1048576,
+        },
+      },
+    ],
   },
   resolve: {
     extensions: ['.js', '.jsx', '.css', '.scss', '.json', '.jpg'],
@@ -70,16 +76,14 @@ module.exports = {
   target: 'electron-renderer',
   externals: [
     (function () {
-      var IGNORES = [
-        'electron'
-      ]
+      var IGNORES = ['electron']
       return function (context, request, callback) {
         if (IGNORES.indexOf(request) >= 0) {
           return callback(null, 'require("' + request + '")')
         }
         return callback()
       }
-    })()
+    })(),
   ],
   plugins: plugins,
   devtool: process.env.NODE_ENV === 'dev' ? 'eval' : false,
@@ -90,16 +94,16 @@ module.exports = {
           name: 'reactIcons',
           priority: 10,
           chunks: 'all',
-          test (module) {
+          test(module) {
             return module.resource && module.resource.includes('react-icons')
-          }
+          },
         },
         commons: {
           name: 'commons',
           chunks: 'initial',
           minChunks: 2,
         },
-      }
-    }
-  }
+      },
+    },
+  },
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,13 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.jsx', '.css', '.scss', '.json', '.jpg'],
-    modules: ['node_modules', 'src/app', 'src/css', 'src/dashboard', 'test'],
+    modules: ['node_modules', 'src/app', 'test'],
+    alias: {
+      app: path.resolve(__dirname, 'src', 'app'),
+      css: path.resolve(__dirname, 'src', 'css'),
+      dashboard: path.resolve(__dirname, 'src', 'dashboard'),
+      test: path.resolve(__dirname, 'test'),
+    },
   },
   target: 'electron-renderer',
   externals: [


### PR DESCRIPTION
# Fix the Build!
The build for Windows was broken in: https://github.com/cameronsutter/plottr_electron/commit/d24e11019a4cf34afd33baf3d3d43e4f8835695a
See: https://ci.appveyor.com/project/cameronsutter/plottr-electron/builds/37389134

I reproduced the problem locally:
```
Entrypoint app = commons.bundle.js commons.map app.bundle.js app.map
Entrypoint css = css.bundle.js css.map
Entrypoint dashboard = reactIcons.bundle.js reactIcons.map commons.bundle.js commons.map dashboard.bundle.js dashboard.map
  [8] external "require(\"electron\")" 42 bytes {1} {3} [built]
  [9] external "path" 42 bytes {1} {3} [built]
 [10] external "fs" 42 bytes {1} {3} [built]
 [33] ./common/utils/settings.js 613 bytes {0} [built]
 [45] ./common/utils/MPQ.js 3.22 KiB {0} [built]
 [97] ./common/utils/rollbar.js 2.31 KiB {0} [built]
[160] ../locales/index.js 1.07 KiB {0} [built]
[161] ./common/utils/known_files.js 2.79 KiB {0} [built]
[162] ./common/utils/temp_files.js 1.4 KiB {0} [built]
[197] ../node_modules/pltr/v2/index.js + 80 modules 336 KiB {0} [built]
      |    81 modules
[231] ./common/utils/backup.js 2.28 KiB {0} [built]
[232] ./common/utils/mixpanel.js 739 bytes {0} [built]
[342] ./app/index.js 9.21 KiB {1} [built]
[575] ./css/index.js 73 bytes {2} [built]
[582] ./dashboard/index.js 2 KiB {3} [built]
    + 820 hidden modules

ERROR in ./common/exporter/scrivener/v2/exporters/chapters.js
Module not found: Error: Can't resolve 'app/helpers/cards' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/chapters.js 16:14-42
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/chapters.js
Module not found: Error: Can't resolve 'app/selectors/cards' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/chapters.js 14:13-43
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/characters.js
Module not found: Error: Can't resolve 'app/selectors/categories' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/characters.js 12:18-53
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/chapters.js
Module not found: Error: Can't resolve 'app/selectors/chapters' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/chapters.js 12:16-49
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/characters.js
Module not found: Error: Can't resolve 'app/selectors/characters' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/characters.js 10:18-53
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/chapters.js
Module not found: Error: Can't resolve 'app/selectors/lines' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/chapters.js 20:13-43
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/notes.js
Module not found: Error: Can't resolve 'app/selectors/notes' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/notes.js 10:13-43
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/places.js
Module not found: Error: Can't resolve 'app/selectors/places' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/places.js 10:14-45
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./common/exporter/scrivener/v2/exporters/chapters.js
Module not found: Error: Can't resolve 'app/selectors/ui' in 'c:\Users\edwar\wip\plottr_electron\src\common\exporter\scrivener\v2\exporters'
 @ ./common/exporter/scrivener/v2/exporters/chapters.js 18:10-37
 @ ./common/exporter/scrivener/v2/exporter.js
 @ ./app/index.js

ERROR in ./app/index.js
Module not found: Error: Can't resolve 'containers/App' in 'c:\Users\edwar\wip\plottr_electron\src\app'
 @ ./app/index.js 15:34-59

ERROR in ./app/index.js
Module not found: Error: Can't resolve 'store/configureStore' in 'c:\Users\edwar\wip\plottr_electron\src\app'
 @ ./app/index.js 17:22-53

ERROR in ../node_modules/pltr/v2/reducers/categories.js
Module not found: Error: Can't resolve 'store/newIds' in 'c:\Users\edwar\wip\plottr_electron\node_modules\pltr\v2\reducers'
 @ ../node_modules/pltr/v2/reducers/categories.js 5:0-38 34:13-19
 @ ../node_modules/pltr/v2/reducers/main.js
 @ ../node_modules/pltr/v2/reducers/root.js
 @ ../node_modules/pltr/v2/index.js
 @ ./app/index.js
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! plottr@2021.1.13 pack:windows: `webpack`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the plottr@2021.1.13 pack:windows script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\edwar\AppData\Roaming\npm-cache\_logs\2021-01-22T11_19_18_031Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! plottr@2021.1.13 dist:windows: `node build/initEnv.js && npm run pack:windows && electron-builder -w`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the plottr@2021.1.13 dist:windows script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\edwar\AppData\Roaming\npm-cache\_logs\2021-01-22T11_19_18_061Z-debug.log
```

It looks like webpack has a hard time resolving `src/app` as a module on Windows from the exporter(!?)
I'm not quite sure why we marked it as a module rather than an alias?

# Proposed Solution
Change modules to aliases with resolved paths.
In the webpack config I migrated a bunch of folders which were marked as modules to aliases with absolutely resolve paths using `path.resolve(__dirname...`.
This appears to have solved the problem.
```
c:\Users\edwar\wip\plottr_electron>npm run dist:windows
npm run dist:windows

> plottr@2021.1.13 dist:windows c:\Users\edwar\wip\plottr_electron
> node build/initEnv.js && npm run pack:windows && electron-builder -w

writing env variables

> plottr@2021.1.13 pack:windows c:\Users\edwar\wip\plottr_electron
> webpack

Hash: 60f2a8d0368747ef48ed
Version: webpack 4.35.0
Time: 19087ms
Built at: 22/01/2021 13:28:29
               Asset      Size  Chunks             Chunk Names
       app.bundle.js  1.24 MiB       2  [emitted]  app
             app.map  4.28 MiB       2  [emitted]  app
   commons.bundle.js  1.72 MiB       0  [emitted]  commons
         commons.map  5.49 MiB       0  [emitted]  commons
       css.bundle.js   315 KiB       3  [emitted]  css
             css.map   334 KiB       3  [emitted]  css
 dashboard.bundle.js   320 KiB       4  [emitted]  dashboard
       dashboard.map   954 KiB       4  [emitted]  dashboard
reactIcons.bundle.js  1.86 MiB       1  [emitted]  reactIcons
      reactIcons.map   2.3 MiB       1  [emitted]  reactIcons
Entrypoint app = reactIcons.bundle.js reactIcons.map commons.bundle.js commons.map app.bundle.js app.map
Entrypoint css = commons.bundle.js commons.map css.bundle.js css.map
Entrypoint dashboard = reactIcons.bundle.js reactIcons.map commons.bundle.js commons.map dashboard.bundle.js dashboard.map
  [11] external "require(\"electron\")" 42 bytes {2} {4} [built]
  [16] external "path" 42 bytes {2} {4} [built]
  [18] external "fs" 42 bytes {2} {4} [built]
  [38] ./common/utils/settings.js 613 bytes {0} [built]
  [59] ./common/utils/MPQ.js 3.22 KiB {0} [built]
  [92] ../node_modules/pltr/v2/index.js + 75 modules 133 KiB {0} [built]
       |    76 modules
 [119] ./common/utils/rollbar.js 2.31 KiB {0} [built]
 [261] ./common/utils/files.js 531 bytes {0} [built]
 [263] ./common/utils/backup.js 2.28 KiB {0} [built]
 [267] ../locales/index.js 1.07 KiB {0} [built]
 [268] ./common/utils/known_files.js 2.79 KiB {0} [built]
 [269] ./common/utils/temp_files.js 1.4 KiB {0} [built]
 [468] ./app/index.js 9.21 KiB {2} [built]
[1050] ./css/index.js 73 bytes {3} [built]
[1055] ./dashboard/index.js 2 KiB {4} [built]
    + 1135 hidden modules
  • electron-builder  version=22.8.0 os=10.0.18363
  • loaded configuration  file=package.json ("build" field)
  • packaging       platform=win32 arch=x64 electron=8.2.4 appOutDir=dist\win-unpacked
  • cannot unpack electron zip file, will be re-downloaded  error=zip: not a valid zip file
  • downloading     url=https://github.com/electron/electron/releases/download/v8.2.4/electron-v8.2.4-win32-x64.zip size=71 MB parts=8
  • downloaded      url=https://github.com/electron/electron/releases/download/v8.2.4/electron-v8.2.4-win32-x64.zip duration=23.678s
  • packaging       platform=win32 arch=ia32 electron=8.2.4 appOutDir=dist\win-ia32-unpacked
  • downloading     url=https://github.com/electron/electron/releases/download/v8.2.4/electron-v8.2.4-win32-ia32.zip size=68 MB parts=8
  • downloaded      url=https://github.com/electron/electron/releases/download/v8.2.4/electron-v8.2.4-win32-ia32.zip duration=23.347s
  • building        target=nsis file=dist\Plottr-win-installer-latest.exe archs=x64, ia32 oneClick=false perMachine=true
  • downloading     url=https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z size=1.3 MB parts=1
  • downloaded      url=https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z duration=4.781s
  • building block map  blockMapFile=dist\Plottr-win-installer-latest.exe.blockmap