### PR TITLE
Enable templates for scene creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ screenshots/*
 .env
 .DS_Store
 data/*
+*.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -17717,8 +17717,8 @@
       }
     },
     "pltr": {
-      "version": "git+https://github.com/Plotinator/pltr.git#a176434ec8daf6adc5c38c4ccdbe5e325de00d68",
-      "from": "git+https://github.com/Plotinator/pltr.git#a176434",
+      "version": "git+https://github.com/Plotinator/pltr.git#aad107f3e70671aaa8ecfa8eb39bdf2c5090b66a",
+      "from": "git+https://github.com/Plotinator/pltr.git#aad107f",
       "requires": {
         "dom-parser": "^0.1.6",
         "format-message": "^6.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plottr",
-  "version": "2021.1.27-beta.2",
+  "version": "2021.1.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17717,8 +17717,8 @@
       }
     },
     "pltr": {
-      "version": "git+https://github.com/Plotinator/pltr.git#a10313d397dcfa15e7644512bf84fed6d2d22c21",
-      "from": "git+https://github.com/Plotinator/pltr.git#a10313d",
+      "version": "git+https://github.com/Plotinator/pltr.git#a176434ec8daf6adc5c38c4ccdbe5e325de00d68",
+      "from": "git+https://github.com/Plotinator/pltr.git#a176434",
       "requires": {
         "dom-parser": "^0.1.6",
         "format-message": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mixpanel-browser": "^2.38.0",
     "node-machine-id": "^1.1.12",
     "pagedown": "^1.1.0",
-    "pltr": "https://github.com/Plotinator/pltr.git#a176434",
+    "pltr": "https://github.com/Plotinator/pltr.git#aad107f",
     "pretty-date": "^0.2.0",
     "react": "^16.8.6",
     "react-beautiful-dnd": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mixpanel-browser": "^2.38.0",
     "node-machine-id": "^1.1.12",
     "pagedown": "^1.1.0",
-    "pltr": "https://github.com/Plotinator/pltr.git#a10313d",
+    "pltr": "https://github.com/Plotinator/pltr.git#a176434",
     "pretty-date": "^0.2.0",
     "react": "^16.8.6",
     "react-beautiful-dnd": "^13.0.0",

--- a/shared/initialState.js
+++ b/shared/initialState.js
@@ -141,6 +141,7 @@ const line = {
   id: 1,
   bookId: 1,
   color: '#6cace4',
+  backgroundColor: '#6cace419',
   title: '',
   position: 0,
   characterId: null,
@@ -151,6 +152,7 @@ const line = {
 const seriesLine = {
   id: 1,
   color: '#6cace4',
+  backgroundColor: '#6cace419',
   title: '',
   position: 0,
   expanded: null,

--- a/src/app/components/EditAttribute.js
+++ b/src/app/components/EditAttribute.js
@@ -10,6 +10,7 @@ import { connect } from 'react-redux'
 const CustomAttributeActions = actions.customAttributeActions
 
 const EditAttribute = ({
+  templateAttribute,
   name,
   type,
   inputId,
@@ -70,24 +71,26 @@ const EditAttribute = ({
         }}
       />
       {!editing ? <ControlLabel>{name}</ControlLabel> : null}
-      <div className="card-dialog__custom-attributes-edit-controls">
-        <Button
-          bsSize="small"
-          onClick={() => {
-            setEditing(!editing)
-          }}
-        >
-          <Glyphicon glyph="edit" />
-        </Button>
-        <Button
-          bsSize="small"
-          onClick={() => {
-            setDeleting(true)
-          }}
-        >
-          <Glyphicon glyph="trash" />
-        </Button>
-      </div>
+      {!templateAttribute ? (
+        <div className="card-dialog__custom-attributes-edit-controls">
+          <Button
+            bsSize="small"
+            onClick={() => {
+              setEditing(!editing)
+            }}
+          >
+            <Glyphicon glyph="edit" />
+          </Button>
+          <Button
+            bsSize="small"
+            onClick={() => {
+              setDeleting(true)
+            }}
+          >
+            <Glyphicon glyph="trash" />
+          </Button>
+        </div>
+      ) : null}
     </div>
   )
 
@@ -129,6 +132,7 @@ const EditAttribute = ({
 }
 
 EditAttribute.propTypes = {
+  templateAttribute: PropTypes.bool,
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,

--- a/src/app/components/EditAttribute.js
+++ b/src/app/components/EditAttribute.js
@@ -12,6 +12,7 @@ const CustomAttributeActions = actions.customAttributeActions
 const EditAttribute = ({
   name,
   type,
+  inputId,
   value,
   index,
   entityType,
@@ -103,7 +104,7 @@ const EditAttribute = ({
         <div>
           <Label />
           <RichText
-            description={entity[name]}
+            description={value || entity[name]}
             onChange={(desc) => handleLongDescriptionChange(name, desc)}
             editable
             autofocus={false}
@@ -114,9 +115,9 @@ const EditAttribute = ({
         <FormGroup>
           <Label />
           <FormControl
-            value={value || ''}
+            value={value || entity[name]}
             type="text"
-            id={`${name}Input`}
+            id={inputId || `${name}Input`}
             onKeyDown={onShortDescriptionKeyDown}
             onKeyPress={onShortDescriptionKeyPress}
             onChange={(event) => handleShortDescriptionChange(name, event.target.value)}
@@ -132,6 +133,7 @@ EditAttribute.propTypes = {
   type: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   value: PropTypes.string,
+  inputId: PropTypes.string,
   entityType: PropTypes.string.isRequired,
   entity: PropTypes.object.isRequired,
   ui: PropTypes.object.isRequired,

--- a/src/app/components/characters/CharacterEditDetails.js
+++ b/src/app/components/characters/CharacterEditDetails.js
@@ -169,8 +169,8 @@ class CharacterEditDetails extends Component {
           <EditAttribute
             index={index}
             entity={character}
+            entityType="character"
             value={this.state.description[attr.name]}
-            entityType={'character'}
             ui={ui}
             handleLongDescriptionChange={this.handleAttrDescriptionChange}
             handleShortDescriptionChange={this.handleAttrDescriptionChange}
@@ -186,10 +186,12 @@ class CharacterEditDetails extends Component {
   renderEditingTemplates() {
     const { character, ui } = this.props
     return character.templates.flatMap((t) => {
-      return t.attributes.map((attr, idx) => (
-        <React.Fragment key={idx}>
+      return t.attributes.map((attr, index) => (
+        <React.Fragment key={index}>
           <EditAttribute
+            index={index}
             entity={character}
+            entityType="character"
             ui={ui}
             inputId={`${t.id}-${attr.name}Input`}
             handleLongDescriptionChange={this.handleTemplateAttrDescriptionChange(t.id, attr.name)}

--- a/src/app/components/characters/CharacterEditDetails.js
+++ b/src/app/components/characters/CharacterEditDetails.js
@@ -79,7 +79,7 @@ class CharacterEditDetails extends Component {
     this.setState({ description })
   }
 
-  handleTemplateAttrDescriptionChange = (id, attr, desc) => {
+  handleTemplateAttrDescriptionChange = (id, attr) => (desc) => {
     let templateAttrs = {
       ...this.state.templateAttrs,
       [id]: {
@@ -104,13 +104,9 @@ class CharacterEditDetails extends Component {
       const { name, type } = attr
       attrs[name] = this.state.description[name]
     })
-    let templates = this.props.character.templates.map((t) => {
+    const templates = this.props.character.templates.map((t) => {
       t.attributes = t.attributes.map((attr) => {
-        if (attr.type == 'paragraph') {
-          attr.value = this.state.templateAttrs[t.id][attr.name]
-        } else {
-          attr.value = findDOMNode(this.refs[`${t.id}-${attr.name}Input`]).value
-        }
+        attr.value = this.state.templateAttrs[t.id][attr.name]
         return attr
       })
       return t
@@ -180,7 +176,6 @@ class CharacterEditDetails extends Component {
             handleShortDescriptionChange={this.handleAttrDescriptionChange}
             onShortDescriptionKeyDown={this.handleEsc}
             onShortDescriptionKeyPress={this.handleEnter}
-            withRef={this.addInputRef}
             {...attr}
           />
         </React.Fragment>
@@ -189,36 +184,22 @@ class CharacterEditDetails extends Component {
   }
 
   renderEditingTemplates() {
-    return this.props.character.templates.flatMap((t) => {
-      return t.attributes.map((attr) => {
-        if (attr.type == 'paragraph') {
-          return (
-            <div key={attr.name}>
-              <ControlLabel>{attr.name}</ControlLabel>
-              <RichText
-                description={attr.value}
-                onChange={(desc) => this.handleTemplateAttrDescriptionChange(t.id, attr.name, desc)}
-                editable
-                autofocus={false}
-                darkMode={this.props.ui.darkMode}
-              />
-            </div>
-          )
-        } else {
-          return (
-            <FormGroup key={attr.name}>
-              <ControlLabel>{attr.name}</ControlLabel>
-              <FormControl
-                type="text"
-                ref={`${t.id}-${attr.name}Input`}
-                defaultValue={attr.value}
-                onKeyDown={this.handleEsc}
-                onKeyPress={this.handleEnter}
-              />
-            </FormGroup>
-          )
-        }
-      })
+    const { character, ui } = this.props
+    return character.templates.flatMap((t) => {
+      return t.attributes.map((attr, idx) => (
+        <React.Fragment key={idx}>
+          <EditAttribute
+            entity={character}
+            ui={ui}
+            inputId={`${t.id}-${attr.name}Input`}
+            handleLongDescriptionChange={this.handleTemplateAttrDescriptionChange(t.id, attr.name)}
+            handleShortDescriptionChange={this.handleTemplateAttrDescriptionChange(t.id, attr.name)}
+            onShortDescriptionKeyDown={this.handleEsc}
+            onShortDescriptionKeyPress={this.handleEnter}
+            {...attr}
+          />
+        </React.Fragment>
+      ))
     })
   }
 

--- a/src/app/components/characters/CharacterEditDetails.js
+++ b/src/app/components/characters/CharacterEditDetails.js
@@ -189,6 +189,7 @@ class CharacterEditDetails extends Component {
       return t.attributes.map((attr, index) => (
         <React.Fragment key={index}>
           <EditAttribute
+            templateAttribute
             index={index}
             entity={character}
             entityType="character"

--- a/src/app/components/story/BookList.js
+++ b/src/app/components/story/BookList.js
@@ -4,7 +4,6 @@ import PropTypes from 'react-proptypes'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import * as BookActions from 'actions/books'
-import * as LineActions from 'actions/lines'
 import * as SceneActions from 'actions/scenes'
 import i18n from 'format-message'
 import Book from './Book'
@@ -13,6 +12,9 @@ import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
 import cx from 'classnames'
 import { chunk, flatten } from 'lodash'
 import { objectId } from '../../store/newIds'
+import { actions } from 'pltr/v2'
+
+const LineActions = actions.lineActions
 
 class BookList extends Component {
   dragDropAreaRef = React.createRef()

--- a/src/app/components/timeline/AddLineRow.js
+++ b/src/app/components/timeline/AddLineRow.js
@@ -6,10 +6,9 @@ import { Row, Cell } from 'react-sticky-table'
 import { Glyphicon } from 'react-bootstrap'
 import i18n from 'format-message'
 import { sortBy } from 'lodash'
-import * as LineActions from 'actions/lines'
 import * as SeriesLineActions from 'actions/seriesLines'
 import TemplatePicker from '../../../common/components/templates/TemplatePicker'
-import { nextColor } from 'store/lineColors'
+import { nextBackgroundColor, nextColor } from 'store/lineColors'
 import {
   card,
   chapter as defaultChapter,
@@ -18,6 +17,9 @@ import {
 import { sortedChaptersByBookSelector, nextChapterIdSelector } from '../../selectors/chapters'
 import { linesByBookSelector, nextLineIdSelector } from '../../selectors/lines'
 import { nextCardIdSelector } from '../../selectors/cards'
+import { actions } from 'pltr/v2'
+
+const LineActions = actions.lineActions
 
 class AddLineRow extends Component {
   state = {
@@ -144,12 +146,14 @@ class AddLineRow extends Component {
       const lastLine = this.getLast(this.allLines)
       const lastPosition = lastLine ? lastLine.position : 0
       const color = nextColor(this.allLines.length)
+      const backgroundColor = nextBackgroundColor(this.allLines.length)
       const newLine = {
         ...tL,
         id: id,
         bookId: bookId,
         position: lastPosition + 1 + tL.position,
         color: color,
+        backgroundColor: backgroundColor,
         fromTemplateId: template.id,
       }
       this.allLines.push(newLine)

--- a/src/app/components/timeline/BlankCard.js
+++ b/src/app/components/timeline/BlankCard.js
@@ -6,9 +6,10 @@ import { bindActionCreators } from 'redux'
 import { Cell } from 'react-sticky-table'
 import * as CardActions from 'actions/cards'
 import i18n from 'format-message'
-import { FormControl, FormGroup, ControlLabel } from 'react-bootstrap'
+import { FormControl, FormGroup, ControlLabel, Glyphicon } from 'react-bootstrap'
 import cx from 'classnames'
 import { isSeriesSelector } from '../../selectors/ui'
+import TemplatePicker from '../../../common/components/templates/TemplatePicker'
 
 class BlankCard extends Component {
   constructor(props) {
@@ -16,6 +17,10 @@ class BlankCard extends Component {
     this.state = {
       creating: false,
       dropping: false,
+      templateHover: false,
+      defaultHover: false,
+      showTemplatePicker: false,
+      templates: [],
     }
   }
 
@@ -47,8 +52,14 @@ class BlankCard extends Component {
 
   saveCreate = () => {
     const newCard = this.buildCard(findDOMNode(this.refs.titleInput).value)
-    this.props.actions.addCard(newCard)
-    this.setState({ creating: false })
+    this.props.actions.addCard(
+      Object.assign(newCard, this.state.templates ? { templates: this.state.templates } : {})
+    )
+    this.setState({
+      creating: false,
+      templates: [],
+    })
+    if (this.props.onDone) this.props.onDone()
   }
 
   handleFinishCreate = (event) => {
@@ -65,9 +76,14 @@ class BlankCard extends Component {
   buildCard(title) {
     const { chapterId, lineId } = this.props
     if (this.props.isSeries) {
-      return { title, beatId: chapterId, seriesLineId: lineId, positionWithinLine: 0 }
+      return {
+        title,
+        beatId: chapterId,
+        seriesLineId: lineId,
+        positionWithinLine: this.props.positionWithinLine || 0,
+      }
     } else {
-      return { title, chapterId, lineId, positionWithinLine: 0 }
+      return { title, chapterId, lineId, positionWithinLine: this.props.positionWithinLine || 0 }
     }
   }
 
@@ -89,14 +105,104 @@ class BlankCard extends Component {
     }
   }
 
+  onAddWithTemplateHover = () => {
+    this.setState({
+      templateHover: true,
+    })
+  }
+
+  onAddWithTemplateLeave = () => {
+    this.setState({
+      templateHover: false,
+    })
+  }
+
+  onAddWithDefaultHover = () => {
+    this.setState({
+      defaultHover: true,
+    })
+  }
+
+  onAddWithDefaultLeave = () => {
+    this.setState({
+      defaultHover: false,
+    })
+  }
+
+  showTemplatePicker = () => {
+    this.setState({
+      showTemplatePicker: true,
+    })
+  }
+
+  handleChooseTemplate = (template) => {
+    const newTemplates = this.state.templates.find(({ id }) => id === template.id)
+      ? this.state.templates
+      : [template, ...this.state.templates]
+
+    this.setState({
+      templates: newTemplates,
+      showTemplatePicker: false,
+      creating: true,
+    })
+  }
+
+  closeTemplatePicker = () => {
+    this.setState({ showTemplatePicker: false })
+  }
+
   renderBlank() {
-    var blankCardStyle = {
+    const blankCardStyle = {
       borderColor: this.props.color,
+      color: this.props.color,
     }
+    const addWithTemplateStyle = this.state.templateHover
+      ? {
+          background: this.props.backgroundColor,
+        }
+      : {}
+    const addWithDefaultStyle = this.state.defaultHover
+      ? {
+          background: this.props.backgroundColor,
+        }
+      : {}
+    const bodyClass = this.props.verticalInsertion
+      ? 'vertical-blank-card__body'
+      : 'blank-card__body'
     return (
-      <div
-        className={cx('blank-card__body', { hover: this.state.dropping })}
-        style={blankCardStyle}
+      <div className={cx(bodyClass, { hover: this.state.dropping })} style={blankCardStyle}>
+        <div
+          className="template"
+          onClick={this.showTemplatePicker}
+          onMouseEnter={this.onAddWithTemplateHover}
+          onMouseLeave={this.onAddWithTemplateLeave}
+          style={addWithTemplateStyle}
+        >
+          {i18n('Use Template')}
+        </div>
+        <div
+          className="non-template"
+          onClick={this.startCreating}
+          onMouseEnter={this.onAddWithDefaultHover}
+          onMouseLeave={this.onAddWithDefaultLeave}
+          style={addWithDefaultStyle}
+        >
+          <Glyphicon glyph="plus" />
+        </div>
+      </div>
+    )
+  }
+
+  renderTemplatePicker() {
+    if (!this.state.showTemplatePicker) return null
+
+    return (
+      <TemplatePicker
+        type={['scenes']}
+        modal={true}
+        isOpen={this.state.showTemplatePicker}
+        close={this.closeTemplatePicker}
+        onChooseTemplate={this.handleChooseTemplate}
       />
     )
   }
@@ -105,8 +211,9 @@ class BlankCard extends Component {
     const cardStyle = {
       borderColor: this.props.color,
     }
+    const bodyClass = this.props.verticalInsertion ? 'vertical-card__body' : 'card__body'
     return (
-      <div className="card__body" style={cardStyle}>
+      <div className={bodyClass} style={cardStyle}>
         <FormGroup>
           <ControlLabel>{i18n('Scene Title')}</ControlLabel>
           <FormControl
@@ -135,20 +242,26 @@ class BlankCard extends Component {
 
     const vertical = this.props.orientation === 'vertical'
     return (
-      <Cell>
-        <div
-          className={cx('card__cell', { vertical })}
-          onDragEnter={this.handleDragEnter}
-          onDragOver={this.handleDragOver}
-          onDragLeave={this.handleDragLeave}
-          onDrop={this.handleDrop}
-          onClick={this.startCreating}
-        >
-          {/* This div is necessary to match the structure of scene cell cards
-              and thus get the styles to apply in the same way (flexbox) */}
-          <div>{body}</div>
-        </div>
-      </Cell>
+      <>
+        {this.props.verticalInsertion ? (
+          body
+        ) : (
+          <Cell>
+            <div
+              className={cx('card__cell', { vertical })}
+              onDragEnter={this.handleDragEnter}
+              onDragOver={this.handleDragOver}
+              onDragLeave={this.handleDragLeave}
+              onDrop={this.handleDrop}
+            >
+              {/* This div is necessary to match the structure of scene cell cards
+                 and thus get the styles to apply in the same way (flexbox) */}
+              <div>{body}</div>
+            </div>
+          </Cell>
+        )}
+        {this.renderTemplatePicker()}
+      </>
     )
   }
 
@@ -156,6 +269,9 @@ class BlankCard extends Component {
     if (this.state.dropping != nextState.dropping) return true
     if (this.state.creating != nextState.creating) return true
     if (this.props.color != nextProps.color) return true
+    if (this.state.templateHover !== nextState.templateHover) return true
+    if (this.state.defaultHover !== nextState.defaultHover) return true
+    if (this.state.showTemplatePicker !== nextState.showTemplatePicker) return true
     return false
   }
 }
@@ -163,10 +279,14 @@ class BlankCard extends Component {
 BlankCard.propTypes = {
   chapterId: PropTypes.number,
   lineId: PropTypes.number,
+  verticalInsertion: PropTypes.bool,
   color: PropTypes.string.isRequired,
+  backgroundColor: PropTypes.string.isRequired,
   currentTimeline: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   orientation: PropTypes.string,
   isSeries: PropTypes.bool,
+  positionWithinLine: PropTypes.number,
+  onDone: PropTypes.func,
 }
 
 function mapStateToProps(state) {

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -266,12 +266,12 @@ class CardDialog extends Component {
     const { card, ui, customAttributes } = this.props
     return customAttributes.map((attr, index) => {
       return (
-        <React.Fragment key={`custom-attribute-${idx}-${attr.name}`}>
+        <React.Fragment key={`custom-attribute-${index}-${attr.name}`}>
           <EditAttribute
             index={index}
             entity={card}
+            entityType="scene"
             value={this.state.shortAttributes[attr.name]}
-            entityType={'scene'}
             ui={ui}
             handleLongDescriptionChange={this.handleParagraphAttrChange}
             handleShortDescriptionChange={this.handleShortAttrChange}
@@ -287,10 +287,12 @@ class CardDialog extends Component {
   renderEditingTemplates() {
     const { card, ui } = this.props
     return card.templates.flatMap((t) => {
-      return t.attributes.map((attr, idx) => (
-        <React.Fragment key={`template-attribute-${idx}-${t.id}-${attr.name}`}>
+      return t.attributes.map((attr, index) => (
+        <React.Fragment key={`template-attribute-${index}-${t.id}-${attr.name}`}>
           <EditAttribute
+            index={index}
             entity={card}
+            entityType="scene"
             ui={ui}
             inputId={`${t.id}-${attr.name}Input`}
             handleLongDescriptionChange={this.handleTemplateAttrDescriptionChange(t.id, attr.name)}

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -290,6 +290,7 @@ class CardDialog extends Component {
       return t.attributes.map((attr, index) => (
         <React.Fragment key={`template-attribute-${index}-${t.id}-${attr.name}`}>
           <EditAttribute
+            templateAttribute
             index={index}
             entity={card}
             entityType="scene"

--- a/src/app/components/timeline/LineTitleCell.js
+++ b/src/app/components/timeline/LineTitleCell.js
@@ -12,7 +12,6 @@ import {
   ControlLabel,
 } from 'react-bootstrap'
 import { Cell } from 'react-sticky-table'
-import * as LineActions from 'actions/lines'
 import * as SeriesLineActions from 'actions/seriesLines'
 import ColorPicker from '../colorpicker'
 import DeleteConfirmModal from '../dialogs/DeleteConfirmModal'
@@ -23,6 +22,9 @@ import { FaExpandAlt, FaCompressAlt } from 'react-icons/fa'
 import { lineIsExpandedSelector } from '../../selectors/lines'
 import Floater from 'react-floater'
 import { truncateTitle } from 'helpers/cards'
+import { actions } from 'pltr/v2'
+
+const LineActions = actions.lineActions
 
 const CELL_WIDTH = 200
 

--- a/src/app/components/timeline/SceneCardAdd.js
+++ b/src/app/components/timeline/SceneCardAdd.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
+import BlankCard from './BlankCard'
 import PropTypes from 'react-proptypes'
-import i18n from 'format-message'
 import { findDOMNode } from 'react-dom'
-import { Glyphicon, FormGroup, FormControl, ControlLabel } from 'react-bootstrap'
+import { Glyphicon } from 'react-bootstrap'
 import cx from 'classnames'
 
 export default class SceneCardAdd extends Component {
@@ -11,6 +11,10 @@ export default class SceneCardAdd extends Component {
   saveCreate = () => {
     const title = findDOMNode(this.refs.titleInput).value
     this.props.addCard({ title, positionWithinLine: this.props.positionWithinLine + 1 })
+    this.setState({ creating: false })
+  }
+
+  stopCreating = () => {
     this.setState({ creating: false })
   }
 
@@ -24,6 +28,7 @@ export default class SceneCardAdd extends Component {
   handleCancelCreate = (event) => {
     if (event.which === 27) {
       //esc
+      window.removeEventListener('keydown', this.handleCancelCreate)
       this.setState({ creating: false })
     }
   }
@@ -40,6 +45,7 @@ export default class SceneCardAdd extends Component {
   }
 
   startCreating = () => {
+    window.addEventListener('keydown', this.handleCancelCreate)
     this.setState({ creating: true })
   }
 
@@ -76,19 +82,16 @@ export default class SceneCardAdd extends Component {
         borderColor: this.props.color,
       }
       return (
-        <div className="card__body" style={cardStyle}>
-          <FormGroup>
-            <ControlLabel>{i18n('Scene Title')}</ControlLabel>
-            <FormControl
-              type="text"
-              autoFocus
-              ref="titleInput"
-              bsSize="small"
-              onBlur={this.handleBlur}
-              onKeyDown={this.handleCancelCreate}
-              onKeyPress={this.handleFinishCreate}
-            />
-          </FormGroup>
+        <div className="vertical-blank-card__wrapper">
+          <BlankCard
+            verticalInsertion
+            chapterId={this.props.chapterId}
+            lineId={this.props.lineId}
+            positionWithinLine={this.props.positionWithinLine + 1}
+            color={this.props.color}
+            backgroundColor={this.props.backgroundColor}
+            onDone={this.stopCreating}
+          />
         </div>
       )
     } else {
@@ -128,10 +131,13 @@ export default class SceneCardAdd extends Component {
 
   static propTypes = {
     color: PropTypes.string.isRequired,
+    backgroundColor: PropTypes.string.isRequired,
     positionWithinLine: PropTypes.number.isRequired,
     moveCard: PropTypes.func.isRequired,
     addCard: PropTypes.func.isRequired,
     allowDrop: PropTypes.bool.isRequired,
+    chapterId: PropTypes.number.isRequired,
+    lineId: PropTypes.number.isRequired,
     dropPosition: PropTypes.number,
   }
 }

--- a/src/app/components/timeline/ScenesCell.js
+++ b/src/app/components/timeline/ScenesCell.js
@@ -70,7 +70,15 @@ class ScenesCell extends PureComponent {
   }
 
   renderCards(arentHidden) {
-    const { chapterId, lineId, chapterPosition, linePosition, color, cards } = this.props
+    const {
+      chapterId,
+      lineId,
+      chapterPosition,
+      linePosition,
+      color,
+      backgroundColor,
+      cards,
+    } = this.props
     const numOfCards = cards.length
     const idxOfCards = numOfCards - 1
     return cards.map((card, idx) => {
@@ -94,11 +102,14 @@ class ScenesCell extends PureComponent {
           {arentHidden ? (
             <SceneCardAdd
               color={color}
+              backgroundColor={backgroundColor}
               positionWithinLine={idx}
               moveCard={this.moveSceneCard}
               addCard={this.addSceneCard}
               allowDrop={isLastOne}
               dropPosition={cards.length}
+              chapterId={chapterId}
+              lineId={lineId}
             />
           ) : null}
         </div>
@@ -137,10 +148,13 @@ class ScenesCell extends PureComponent {
             </div>
           </Floater>
           <SceneCardAdd
+            backgroundColor={this.props.backgroundColor}
             color={this.props.color}
             positionWithinLine={numOfCards}
             moveCard={this.moveSceneCard}
             addCard={this.addSceneCard}
+            chapterId={this.props.chapterId}
+            lineId={this.props.lineId}
             allowDrop
           />
         </div>
@@ -160,6 +174,7 @@ ScenesCell.propTypes = {
   chapterId: PropTypes.number.isRequired,
   lineId: PropTypes.number.isRequired,
   color: PropTypes.string.isRequired,
+  backgroundColor: PropTypes.string.isRequired,
   linePosition: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   chapterPosition: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   ui: PropTypes.object.isRequired,

--- a/src/app/components/timeline/TimelineTable.js
+++ b/src/app/components/timeline/TimelineTable.js
@@ -12,7 +12,6 @@ import ChapterTitleCell from './ChapterTitleCell'
 import AddLineRow from './AddLineRow'
 import * as UIActions from 'actions/ui'
 import * as SceneActions from 'actions/scenes'
-import * as LineActions from 'actions/lines'
 import * as BeatActions from 'actions/beats'
 import * as SeriesLineActions from 'actions/seriesLines'
 import * as CardActions from 'actions/cards'
@@ -25,9 +24,14 @@ import { sortedLinesByBookSelector } from '../../selectors/lines'
 import { findDOMNode } from 'react-dom'
 import { cardMapSelector } from '../../selectors/cards'
 import { isSeriesSelector } from '../../selectors/ui'
+import { actions } from 'pltr/v2'
+
+const LineActions = actions.lineActions
 
 class TimelineTable extends Component {
-  state = { tableLength: 0 }
+  state = {
+    tableLength: 0,
+  }
 
   setLength = () => {
     const table = findDOMNode(this.props.tableRef)
@@ -231,11 +235,18 @@ class TimelineTable extends Component {
             chapterPosition={chapterPosition}
             linePosition={line.position}
             color={line.color}
+            backgroundColor={line.backgroundColor}
           />
         )
       } else {
         cells.push(
-          <BlankCard chapterId={chapterId} lineId={line.id} key={key} color={line.color} />
+          <BlankCard
+            chapterId={chapterId}
+            lineId={line.id}
+            key={key}
+            color={line.color}
+            backgroundColor={line.backgroundColor}
+          />
         )
       }
       return cells
@@ -259,11 +270,18 @@ class TimelineTable extends Component {
             chapterPosition={chapter.position}
             linePosition={linePosition}
             color={line.color}
+            backgroundColor={line.backgroundColor}
           />
         )
       } else {
         cells.push(
-          <BlankCard chapterId={chapter.id} lineId={line.id} key={key} color={line.color} />
+          <BlankCard
+            chapterId={chapter.id}
+            lineId={line.id}
+            key={key}
+            color={line.color}
+            backgroundColor={line.backgroundColor}
+          />
         )
       }
       return cells

--- a/src/app/components/timeline/TopRow.js
+++ b/src/app/components/timeline/TopRow.js
@@ -5,7 +5,6 @@ import { bindActionCreators } from 'redux'
 import { Row, Cell } from 'react-sticky-table'
 import { Glyphicon } from 'react-bootstrap'
 import * as SceneActions from 'actions/scenes'
-import * as LineActions from 'actions/lines'
 import * as BeatActions from 'actions/beats'
 import * as SeriesLineActions from 'actions/seriesLines'
 import ChapterTitleCell from 'components/timeline/ChapterTitleCell'
@@ -18,6 +17,9 @@ import { nextId } from '../../store/newIds'
 import { sortedChaptersByBookSelector } from '../../selectors/chapters'
 import { sortedLinesByBookSelector } from '../../selectors/lines'
 import { isSeriesSelector } from '../../selectors/ui'
+import { actions } from 'pltr/v2'
+
+const LineActions = actions.lineActions
 
 class TopRow extends Component {
   handleReorderChapters = (originalPosition, droppedPosition) => {

--- a/src/app/reducers/main.js
+++ b/src/app/reducers/main.js
@@ -7,7 +7,6 @@ import tags from './tags'
 import characters from './characters'
 import chapters from './chapters'
 import cards from './cards'
-import lines from './lines'
 import notes from './notes'
 import images from './images'
 import beats from './beats'
@@ -16,7 +15,7 @@ import series from './series'
 import seriesLines from './seriesLines'
 import categories from './categories'
 
-const { customAttributes } = reducers
+const { customAttributes, lines } = reducers
 
 const mainReducer = combineReducers({
   ui,

--- a/src/app/reducers/seriesLines.js
+++ b/src/app/reducers/seriesLines.js
@@ -18,7 +18,7 @@ import {
 import { seriesLine } from '../../../shared/initialState'
 import { newFileSeriesLines } from '../../../shared/newFileState'
 import { nextId } from 'store/newIds'
-import { nextColor } from 'store/lineColors'
+import { nextBackgroundColor, nextColor } from 'store/lineColors'
 import { nextPosition, positionReset } from 'helpers/lists'
 
 const initialState = [seriesLine]
@@ -31,6 +31,7 @@ export default function seriesLines(state = initialState, action) {
           id: nextId(state),
           title: '',
           color: nextColor(state.length),
+          backgroundColor: nextBackgroundColor(state.length),
           position: nextPosition(state),
           expanded: null,
         },
@@ -45,6 +46,7 @@ export default function seriesLines(state = initialState, action) {
             id: l.id,
             title: l.title,
             color: nextColor(state.length + idx),
+            backgroundColor: nextBackgroundColor(state.length + idx),
             position: position + idx,
           }
         }),
@@ -85,6 +87,7 @@ export default function seriesLines(state = initialState, action) {
           id: nextId(state),
           title: i18n('Main Plot'),
           color: nextColor(0),
+          backgroundColor: nextBackgroundColor(0),
           position: 0,
           expanded: null,
         },

--- a/src/app/store/lineColors.js
+++ b/src/app/store/lineColors.js
@@ -14,3 +14,20 @@ export function nextColor(length) {
       return '#0b1117' // black
   }
 }
+
+export function nextBackgroundColor(length) {
+  switch (length) {
+    case 0:
+      return '#6cace419' // blue
+    case 1:
+      return '#78be2019' // green
+    case 2:
+      return '#e5554f19' // red
+    case 3:
+      return '#ff7f3219' // orange
+    case 4:
+      return '#ffc72c19' // yellow
+    default:
+      return '#0b111719' // black
+  }
+}

--- a/src/common/components/templates/SceneTemplateDetails.js
+++ b/src/common/components/templates/SceneTemplateDetails.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import PropTypes from 'react-proptypes'
+import i18n from 'format-message'
+
+export default class SceneTemplateDetails extends Component {
+  render() {
+    const attrs = this.props.template.attributes.map((attr) => {
+      return (
+        <tr key={attr.name}>
+          <td>{attr.name}</td>
+          <td>{attr.type}</td>
+        </tr>
+      )
+    })
+
+    return (
+      <div className="panel-body">
+        <h5 className="text-center">{i18n('Attributes')}</h5>
+        <table className="table table-striped">
+          <thead>
+            <tr>
+              <th>{i18n('Name')}</th>
+              <th>{i18n('Type')}</th>
+            </tr>
+          </thead>
+          <tbody>{attrs}</tbody>
+        </table>
+      </div>
+    )
+  }
+
+  static propTypes = {
+    template: PropTypes.object.isRequired,
+  }
+}

--- a/src/common/components/templates/TemplatePicker.js
+++ b/src/common/components/templates/TemplatePicker.js
@@ -13,6 +13,7 @@ import {
 import CharacterTemplateDetails from './CharacterTemplateDetails'
 import PlotlineTemplateDetails from './PlotlineTemplateDetails'
 import ProjectTemplateDetails from './ProjectTemplateDetails'
+import SceneTemplateDetails from './SceneTemplateDetails'
 import cx from 'classnames'
 import TemplateEdit from './TemplateEdit'
 import { FaSave } from 'react-icons/fa'
@@ -168,6 +169,9 @@ export default class TemplatePicker extends Component {
         break
       case 'project':
         details = <ProjectTemplateDetails template={template} />
+        break
+      case 'scenes':
+        details = <SceneTemplateDetails template={template} />
         break
     }
 

--- a/src/common/importer/snowflake/importer.js
+++ b/src/common/importer/snowflake/importer.js
@@ -12,7 +12,7 @@ import {
   line as defaultLine,
 } from '../../../../shared/initialState'
 import { nextPositionInBook } from '../../../app/helpers/lists'
-import { nextColor } from '../../../app/store/lineColors'
+import { nextBackgroundColor, nextColor } from '../../../app/store/lineColors'
 
 export default function Importer(path, isNewFile, state) {
   const importedXML = fs.readFileSync(path, 'utf-8')
@@ -365,6 +365,7 @@ function cards(currentState, json, bookId) {
                 position: nextLinePosition,
                 title: characterName,
                 color: nextColor(nextLinePosition),
+                backgroundColor: nextBackgroundColor(nextLinePosition),
               },
               bookId
             )

--- a/src/common/utils/custom_templates.js
+++ b/src/common/utils/custom_templates.js
@@ -90,7 +90,7 @@ function createScenesTemplate(pltrData, { name, description, link }) {
     name: name,
     description: description,
     link: link,
-    attributes: data.customAttributes.characters,
+    attributes: data.customAttributes.scenes,
   }
   customTemplatesStore.set(id, template)
 }

--- a/src/css/card_block.css.scss
+++ b/src/css/card_block.css.scss
@@ -98,6 +98,16 @@
   z-index: 2;
 }
 
+.vertical-card__body {
+  @extend .vertical-blank-card__body;
+  margin-top: 17px;
+
+  .form-group {
+    display: block;
+    padding: 0;
+  }
+}
+
 .card__title {
   padding: 10px;
   flex-grow: 1;
@@ -108,11 +118,52 @@
   stroke-width: $svg-line-width;
 }
 
+.vertical-blank-card__wrapper {
+  margin: auto;
+}
+
 .blank-card__body {
   @extend .card__body;
   border: 3px dashed black;
   visibility: hidden;
   cursor: pointer;
+  margin-left: 5px;
+  margin-bottom: 50px;
+  display: flex;
+  justify-content: space-between;
+
+  div {
+    padding: 10px 5px;
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  div.template {
+    @include application-text;
+    text-align: center;
+  }
+}
+
+.vertical-blank-card__body {
+  @extend .card__body;
+  border: 3px dashed black;
+  margin-top: 17px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+
+  div {
+    padding: 10px 5px;
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  div.template {
+    @include application-text;
+    text-align: center;
+  }
 }
 
 .blank-card__body.hover {


### PR DESCRIPTION
# Motivation
To enable users to create scene cards from custom attribute templates.

# UI Modifications
This branch adds UI elements for creating a new card with a template and picking a scene template.

## Creating a Scene with a Template
I copied the way that plotlines are created with templates so that:
 - when you hover of a blank card you see a split button (like plotlines);
 - when you click on the plus icon, we enter the original flow for creating a scene card (i.e. title form appears).
 - when you click on "Use Template" it opens the template picker and when you've picked a template, it advances to the title input form and remembers the template selection.

## Picking a Scene Template
We now have a `SceneTemplateDetails` component wired up to the Template picker when scene templates are selected.

# Non-Functional Changes
The following changes were made to the plumbing to support the UI changes:
 - Reducers and actions for `lines` were migrated to `pltr`.
 - Lines now have a `backgroundColor` to keep the new scene buttons consistent with the line colours.
 - `EditAttribute` now handles template attributes.
 - Blank project creation now includes background colours for lines.