### PR TITLE
Release Bug Fix: blank cards error on close

### DIFF
--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -24,7 +24,7 @@ import { truncateTitle } from '../../helpers/cards'
 import { EditAttribute } from '../EditAttribute'
 
 class CardDialog extends Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = {
       description: props.card.description,
@@ -41,28 +41,28 @@ class CardDialog extends Component {
     })
   }
 
-  componentDidMount () {
+  componentDidMount() {
     window.SCROLLWITHKEYS = false
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.saveEdit()
     window.SCROLLWITHKEYS = true
   }
 
-  deleteCard = e => {
+  deleteCard = (e) => {
     e.stopPropagation()
     this.props.actions.deleteCard(this.props.card.id)
   }
 
-  cancelDelete = e => {
+  cancelDelete = (e) => {
     e.stopPropagation()
-    this.setState({deleting: false})
+    this.setState({ deleting: false })
   }
 
-  handleDelete = e => {
+  handleDelete = (e) => {
     e.stopPropagation()
-    this.setState({deleting: true})
+    this.setState({ deleting: true })
   }
 
   saveAndClose = () => {
@@ -99,7 +99,7 @@ class CardDialog extends Component {
   saveEdit = () => {
     var newTitle = findDOMNode(this.refs.titleInput).value
     const attrs = {}
-    this.props.customAttributes.forEach(attr => {
+    this.props.customAttributes.forEach((attr) => {
       const { name, type } = attr
       if (type == 'paragraph') {
         attrs[name] = this.state.paragraphs[name] || this.props.card[name]
@@ -108,8 +108,8 @@ class CardDialog extends Component {
         attrs[name] = val
       }
     })
-    const templates = this.props.card.templates.map(t => {
-      t.attributes = t.attributes.map(attr => {
+    const templates = (this.props.card.templates || []).map((t) => {
+      t.attributes = t.attributes.map((attr) => {
         if (attr.type == 'paragraph') {
           attr.value = this.state.templateAttrs[t.id][attr.name]
         } else {
@@ -140,27 +140,27 @@ class CardDialog extends Component {
     }
   }
 
-  changeChapter (chapterId) {
+  changeChapter(chapterId) {
     this.props.actions.changeScene(this.props.card.id, chapterId, this.props.ui.currentTimeline)
   }
 
-  changeLine (lineId) {
+  changeLine(lineId) {
     this.props.actions.changeLine(this.props.card.id, lineId, this.props.ui.currentTimeline)
   }
 
-  changeBook (bookId) {
+  changeBook(bookId) {
     this.props.actions.changeBook(this.props.card.id, bookId)
   }
 
-  getCurrentChapter () {
-    return this.props.chapters.find(ch => ch.id == this.props.chapterId)
+  getCurrentChapter() {
+    return this.props.chapters.find((ch) => ch.id == this.props.chapterId)
   }
 
-  getCurrentLine () {
-    return this.props.lines.find(l => l.id == this.props.lineId)
+  getCurrentLine() {
+    return this.props.lines.find((l) => l.id == this.props.lineId)
   }
 
-  getBookTitle () {
+  getBookTitle() {
     const book = this.props.books[this.props.card.bookId]
     if (book) {
       return book.title || i18n('Untitled')
@@ -169,13 +169,19 @@ class CardDialog extends Component {
     }
   }
 
-  renderDelete () {
+  renderDelete() {
     if (!this.state.deleting) return null
 
-    return <DeleteConfirmModal name={this.props.card.title} onDelete={this.deleteCard} onCancel={this.cancelDelete}/>
+    return (
+      <DeleteConfirmModal
+        name={this.props.card.title}
+        onDelete={this.deleteCard}
+        onCancel={this.cancelDelete}
+      />
+    )
   }
 
-  renderEditingCustomAttributes () {
+  renderEditingCustomAttributes() {
     const { card, ui, customAttributes } = this.props
     return customAttributes.map((attr, idx) => {
       return (
@@ -194,63 +200,66 @@ class CardDialog extends Component {
     })
   }
 
-  renderChapterItems () {
+  renderChapterItems() {
     const { chapters, positionOffset, isSeries } = this.props
     return chapters.map((chapter) => {
-      return (<MenuItem key={chapter.id} onSelect={() => this.changeChapter(chapter.id)}>
-        {truncateTitle(
-          chapterTitle(chapter, positionOffset, isSeries),
-          50,
-        )}
-      </MenuItem>)
+      return (
+        <MenuItem key={chapter.id} onSelect={() => this.changeChapter(chapter.id)}>
+          {truncateTitle(chapterTitle(chapter, positionOffset, isSeries), 50)}
+        </MenuItem>
+      )
     })
   }
 
-  renderLineItems () {
+  renderLineItems() {
     return this.props.lines.map((line) => {
-      return (<MenuItem key={line.id} onSelect={() => this.changeLine(line.id)}>
-        {truncateTitle(line.title, 50)}
-      </MenuItem>)
+      return (
+        <MenuItem key={line.id} onSelect={() => this.changeLine(line.id)}>
+          {truncateTitle(line.title, 50)}
+        </MenuItem>
+      )
     })
   }
 
-  renderBooks () {
+  renderBooks() {
     const { books } = this.props
-    return books.allIds.map(id => {
-      return <MenuItem key={id} onSelect={() => this.changeBook(id)}>
-        {books[id].title || i18n('Untitled')}
-      </MenuItem>
+    return books.allIds.map((id) => {
+      return (
+        <MenuItem key={id} onSelect={() => this.changeBook(id)}>
+          {books[id].title || i18n('Untitled')}
+        </MenuItem>
+      )
     })
   }
 
-  renderButtonBar () {
+  renderButtonBar() {
     return (
-      <ButtonToolbar className='card-dialog__button-bar'>
-        <Button onClick={this.props.closeDialog}>
-          {i18n('Cancel')}
-        </Button>
-        <Button bsStyle='success' onClick={this.saveAndClose}>
+      <ButtonToolbar className="card-dialog__button-bar">
+        <Button onClick={this.props.closeDialog}>{i18n('Cancel')}</Button>
+        <Button bsStyle="success" onClick={this.saveAndClose}>
           {i18n('Save')}
         </Button>
-        <Button className='card-dialog__delete' onClick={this.handleDelete} >
+        <Button className="card-dialog__delete" onClick={this.handleDelete}>
           {i18n('Delete')}
         </Button>
       </ButtonToolbar>
     )
   }
 
-  renderTitle () {
+  renderTitle() {
     var title = this.props.card.title
-    return <FormControl
-      style={{fontSize: '24pt', textAlign: 'center', marginBottom: '6px'}}
-      onKeyPress={this.handleEnter}
-      type='text'
-      ref='titleInput'
-      defaultValue={title}
-    />
+    return (
+      <FormControl
+        style={{ fontSize: '24pt', textAlign: 'center', marginBottom: '6px' }}
+        onKeyPress={this.handleEnter}
+        type="text"
+        ref="titleInput"
+        defaultValue={title}
+      />
+    )
   }
 
-  renderBookDropdown () {
+  renderBookDropdown() {
     let bookButton = null
     if (this.props.card.bookId) {
       const handler = () => {
@@ -259,17 +268,24 @@ class CardDialog extends Component {
       }
       bookButton = <Button onClick={handler}>{i18n('View Timeline')}</Button>
     }
-    return <div className='card-dialog__dropdown-wrapper' style={{marginBottom: '5px'}}>
-      <label className='card-dialog__details-label' htmlFor='select-book'>{i18n('Book')}:
-        <DropdownButton id='select-book' className='card-dialog__select-line' title={this.getBookTitle()}>
-          {this.renderBooks()}
-        </DropdownButton>
-      </label>
-      { bookButton }
-    </div>
+    return (
+      <div className="card-dialog__dropdown-wrapper" style={{ marginBottom: '5px' }}>
+        <label className="card-dialog__details-label" htmlFor="select-book">
+          {i18n('Book')}:
+          <DropdownButton
+            id="select-book"
+            className="card-dialog__select-line"
+            title={this.getBookTitle()}
+          >
+            {this.renderBooks()}
+          </DropdownButton>
+        </label>
+        {bookButton}
+      </div>
+    )
   }
 
-  renderLeftSide () {
+  renderLeftSide() {
     const lineDropdownID = 'select-line'
     const chapterDropdownID = 'select-chapter'
 
@@ -284,60 +300,61 @@ class CardDialog extends Component {
     const currentChapterTitle = chapterTitle(this.getCurrentChapter(), positionOffset, isSeries)
 
     return (
-      <div className='card-dialog__left-side'>
-        { bookDropDown }
-        <div className='card-dialog__dropdown-wrapper'>
-          <label
-            className='card-dialog__details-label'
-            htmlFor={lineDropdownID}
-          >
+      <div className="card-dialog__left-side">
+        {bookDropDown}
+        <div className="card-dialog__dropdown-wrapper">
+          <label className="card-dialog__details-label" htmlFor={lineDropdownID}>
             {i18n('Plotline')}:
             <DropdownButton
               id={lineDropdownID}
-              className='card-dialog__select-line'
+              className="card-dialog__select-line"
               title={truncateTitle(this.getCurrentLine().title, 35)}
             >
               {this.renderLineItems()}
             </DropdownButton>
           </label>
         </div>
-        <div className='card-dialog__sdropdown-wrapper'>
-          <label
-            className='card-dialog__details-label'
-            htmlFor={chapterDropdownID}
-          >
+        <div className="card-dialog__sdropdown-wrapper">
+          <label className="card-dialog__details-label" htmlFor={chapterDropdownID}>
             {labelText}:
             <DropdownButton
               id={chapterDropdownID}
-              className='card-dialog__select-scene'
-              title={truncateTitle(currentChapterTitle, 40)}>
+              className="card-dialog__select-scene"
+              title={truncateTitle(currentChapterTitle, 40)}
+            >
               {this.renderChapterItems()}
             </DropdownButton>
           </label>
         </div>
         <SelectList
-          parentId={this.props.card.id} type={'Characters'}
+          parentId={this.props.card.id}
+          type={'Characters'}
           selectedItems={this.props.card.characters}
           allItems={this.props.characters}
           add={this.props.actions.addCharacter}
-          remove={this.props.actions.removeCharacter} />
+          remove={this.props.actions.removeCharacter}
+        />
         <SelectList
-          parentId={this.props.card.id} type={'Places'}
+          parentId={this.props.card.id}
+          type={'Places'}
           selectedItems={this.props.card.places}
           allItems={this.props.places}
           add={this.props.actions.addPlace}
-          remove={this.props.actions.removePlace} />
+          remove={this.props.actions.removePlace}
+        />
         <SelectList
-          parentId={this.props.card.id} type={'Tags'}
+          parentId={this.props.card.id}
+          type={'Tags'}
           selectedItems={this.props.card.tags}
           allItems={this.props.tags}
           add={this.props.actions.addTag}
-          remove={this.props.actions.removeTag} />
+          remove={this.props.actions.removeTag}
+        />
       </div>
     )
   }
 
-  render () {
+  render() {
     const { card, ui } = this.props
     const { selected } = this.state
     return (
@@ -367,7 +384,9 @@ class CardDialog extends Component {
                 </div>
               </div>
               <div
-                className={cx('card-dialog__details-show-hide-wrapper', {hidden: selected !== 'Description'})}
+                className={cx('card-dialog__details-show-hide-wrapper', {
+                  hidden: selected !== 'Description',
+                })}
               >
                 <RichText
                   description={card.description}
@@ -378,7 +397,9 @@ class CardDialog extends Component {
                 />
               </div>
               <div
-                className={cx('card-dialog__custom-attributes', {hidden: selected !== 'Attributes'})}
+                className={cx('card-dialog__custom-attributes', {
+                  hidden: selected !== 'Attributes',
+                })}
               >
                 {this.renderEditingCustomAttributes()}
               </div>
@@ -409,7 +430,7 @@ CardDialog.propTypes = {
   customAttributes: PropTypes.array.isRequired,
 }
 
-function mapStateToProps (state) {
+function mapStateToProps(state) {
   return {
     chapters: sortedChaptersByBookSelector(state.present),
     lines: sortedLinesByBookSelector(state.present),
@@ -424,7 +445,7 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
+function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(CardActions, dispatch),
     uiActions: bindActionCreators(UIActions, dispatch),
@@ -433,7 +454,4 @@ function mapDispatchToProps (dispatch) {
 
 const Pure = PureComponent(CardDialog)
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Pure)
+export default connect(mapStateToProps, mapDispatchToProps)(Pure)


### PR DESCRIPTION
# Release Bug Fix: Blank Cards Error on Close
## Steps to Reproduce
Create a new blank card and chapter by clicking on the plus icon next to a card.
Open the card for editing.
Close the card.

Result: an exception is thrown.

## Proposed Fix
The feature to add a blank card when inserting in between cards creates cards without template values.
The fix (use an empty array if templates aren't present) is a bandage over this and similar causes of the problem because we aim to remove the feature of adding a blank card soon anyway.