### PR TITLE
Don't save attributes on scenes when cancelling the dialog

### DIFF
--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -97,7 +97,8 @@ class CardDialog extends Component {
   }
 
   saveAndClose = () => {
-    this.saveEdit()
+    // componentWillUnmount saves the data (otherwise we get a
+    // duplicate event).
     this.props.closeDialog()
   }
 
@@ -194,6 +195,7 @@ class CardDialog extends Component {
     this.setState({
       addingAttribute: true,
     })
+  }
 
   closeWithoutSaving = () => {
     this.setState(

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -76,6 +76,7 @@ class CardDialog extends Component {
   }
 
   componentWillUnmount() {
+    this.saveEdit()
     window.SCROLLWITHKEYS = true
   }
 

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -76,7 +76,6 @@ class CardDialog extends Component {
   }
 
   componentWillUnmount() {
-    this.saveEdit()
     window.SCROLLWITHKEYS = true
   }
 

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -476,7 +476,7 @@ class CardDialog extends Component {
                 <div className="card-dialog__left-tabs">
                   <div
                     className={cx('card-dialog__details-label card-dialog__tab', {
-                      'card-dialog__tab--selected': selected === 'Description'
+                      'card-dialog__tab--selected': selected === 'Description',
                     })}
                     onClick={this.selectTab('Description')}
                   >
@@ -484,7 +484,7 @@ class CardDialog extends Component {
                   </div>
                   <div
                     className={cx('card-dialog__details-label card-dialog__tab', {
-                      'card-dialog__tab--selected': selected === 'Attributes'
+                      'card-dialog__tab--selected': selected === 'Attributes',
                     })}
                     onClick={this.selectTab('Attributes')}
                   >

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -50,6 +50,7 @@ class CardDialog extends Component {
       selected: 'Description',
       addingAttribute: false,
       newAttributeType: 'text',
+      cancelling: false,
     }
     this.newAttributeInputRef = React.createRef()
   }
@@ -76,7 +77,7 @@ class CardDialog extends Component {
   }
 
   componentWillUnmount() {
-    this.saveEdit()
+    if (!this.state.cancelling) this.saveEdit()
     window.SCROLLWITHKEYS = true
   }
 
@@ -193,6 +194,14 @@ class CardDialog extends Component {
     this.setState({
       addingAttribute: true,
     })
+
+  closeWithoutSaving = () => {
+    this.setState(
+      {
+        cancelling: true,
+      },
+      this.props.closeDialog
+    )
   }
 
   changeChapter(chapterId) {
@@ -331,7 +340,7 @@ class CardDialog extends Component {
   renderButtonBar() {
     return (
       <ButtonToolbar className="card-dialog__button-bar">
-        <Button onClick={this.props.closeDialog}>{i18n('Cancel')}</Button>
+        <Button onClick={this.closeWithoutSaving}>{i18n('Cancel')}</Button>
         <Button bsStyle="success" onClick={this.saveAndClose}>
           {i18n('Save')}
         </Button>


### PR DESCRIPTION
# Bug Fix: Don't Save Attributes When Closing Scene Card Dialogs
This removes the call to save in `componentWillUnmount`.
It has the knock-on effect of not double saving when we hit `save`.

# Considerations
Hitting `esc` still saves and closes.
Is that desirable?

# Updates
After @cameronsutter 's comments, the implementation changed.
It now uses a piece of state to flag that we're unmounting and deliberately preventing a save.
i.e. the default behaviour is to save when the component unmounts.
It will only *not* save when asked to.