### PR TITLE
Add tests for latest features

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -81,7 +81,12 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    '^app(.*)$': '<rootDir>/src/app/$1',
+    '^dashboard(.*)$': '<rootDir>/src/dashboard/$1',
+    '^store(.*)$': '<rootDir>/src/app/store/$1',
+    '^test(.*)$': '<rootDir>/test/$1',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   modulePathIgnorePatterns: ['__tests__/fixtures/*'],

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "extract-strings": "format-message extract -o locales/en.json \"bin/**/*.js\" \"src/**/*.js\" \"shared/**/*.js\" && npm run generate-flipped",
     "generate-flipped": "node ./locales/build-flipped-locale.js",
     "test": "jest",
+    "test:watch": "jest --watch",
     "start-redux-dev-tools": "redux-devtools --hostname=localhost --port=8000",
     "lint-file": "eslint",
     "lint": "eslint ."

--- a/src/app/reducers/__tests__/cards.test.js
+++ b/src/app/reducers/__tests__/cards.test.js
@@ -1,8 +1,98 @@
+import { ADD_CARD, ADD_CARD_IN_CHAPTER } from '../../constants/ActionTypes'
+import { card as defaultCard } from '../../../../shared/initialState'
 import cardsReducer from '../cards'
+import { isEqual, uniq } from 'lodash'
+import { allCardsSelector } from '../../selectors/cards'
+
+// Only these functions should change if we change the structure of
+// the state object.
+const mountToState = (cards) => ({ cards })
+const cardInState = ({ cards }, card) => cards.find((x) => isEqual(x, card))
+const emptyState = []
+const oneCardState = [defaultCard]
 
 describe('cardsReducer', () => {
   it('should produce a valid state object when supplied with an unknown event type', () => {
-    const emptyState = []
-    expect(cardsReducer(emptyState, { type: 'derp' })).toEqual(emptyState)
+    expect(cardsReducer(emptyState, { type: 'herpa' })).toEqual(emptyState)
+  })
+  it('should produce an empty array when given no state object', () => {
+    expect(cardsReducer(null, { type: 'derp' })).toEqual(emptyState)
+  })
+  describe('add card', () => {
+    it('should add the default card if it is given a null card', () => {
+      expect(
+        cardInState(
+          mountToState(cardsReducer(emptyState, { type: ADD_CARD, card: {} })),
+          defaultCard
+        )
+      ).toEqual(defaultCard)
+    })
+    it('should produce a two card state from a one card state', () => {
+      expect(
+        allCardsSelector(mountToState(cardsReducer(oneCardState, { type: ADD_CARD, card: {} })))
+      ).toHaveLength(2)
+    })
+    it('should produce cards with unique ids', () => {
+      expect(
+        uniq(
+          allCardsSelector(
+            mountToState(cardsReducer(oneCardState, { type: ADD_CARD, card: {} }))
+          ).map(({ id }) => id)
+        )
+      ).toHaveLength(2)
+    })
+    it('should produce a one card state from an undefined state object', () => {
+      expect(
+        allCardsSelector(mountToState(cardsReducer(undefined, { type: ADD_CARD, card: {} })))
+      ).toHaveLength(1)
+    })
+  })
+  describe('add card in chapter', () => {
+    it('should add a card at position zero to an empty chapter', () => {
+      expect(
+        cardInState(
+          mountToState(cardsReducer(emptyState, { type: ADD_CARD_IN_CHAPTER, card: defaultCard })),
+          defaultCard
+        )
+      ).toEqual(defaultCard)
+    })
+    describe('given a single card state', () => {
+      describe('and given the re order ids [null, 1]', () => {
+        it('should add a new card at positionWithinLine = 0', () => {
+          expect(
+            allCardsSelector(
+              mountToState(
+                cardsReducer(oneCardState, {
+                  type: ADD_CARD_IN_CHAPTER,
+                  card: defaultCard,
+                  reorderIds: [null, 1],
+                })
+              )
+            ).map(({ id, positionWithinLine }) => [id, positionWithinLine])
+          ).toEqual([
+            [2, 0],
+            [1, 1],
+          ])
+        })
+      })
+      describe('and given the re order ids [1, null]', () => {
+        it('should add a new card at positionWithinLine = 1', () => {
+          expect(
+            allCardsSelector(
+              mountToState(
+                cardsReducer(oneCardState, {
+                  type: ADD_CARD_IN_CHAPTER,
+                  card: defaultCard,
+                  reorderIds: [1, null],
+                })
+              )
+            ).map(({ id, positionWithinLine }) => [id, positionWithinLine])
+          ).toEqual([
+            [2, 1],
+            [1, 0],
+          ])
+        })
+      })
+    })
   })
 })

--- a/src/app/reducers/__tests__/cards.test.js
+++ b/src/app/reducers/__tests__/cards.test.js
@@ -1,0 +1,8 @@
+import cardsReducer from '../cards'
+
+describe('cardsReducer', () => {
+  it('should produce a valid state object when supplied with an unknown event type', () => {
+    const emptyState = []
+    expect(cardsReducer(emptyState, { type: 'derp' })).toEqual(emptyState)
+  })
+})

--- a/src/app/reducers/__tests__/cards.test.js
+++ b/src/app/reducers/__tests__/cards.test.js
@@ -1,4 +1,9 @@
-import { ADD_CARD, ADD_CARD_IN_CHAPTER } from '../../constants/ActionTypes'
+import {
+  ADD_CARD,
+  ADD_CARD_IN_CHAPTER,
+  ADD_LINES_FROM_TEMPLATE,
+  EDIT_CARD_DETAILS,
+} from '../../constants/ActionTypes'
 import { card as defaultCard } from '../../../../shared/initialState'
 import cardsReducer from '../cards'
 import { isEqual, uniq } from 'lodash'
@@ -8,8 +13,19 @@ import { allCardsSelector } from '../../selectors/cards'
 // the state object.
 const mountToState = (cards) => ({ cards })
 const cardInState = ({ cards }, card) => cards.find((x) => isEqual(x, card))
-const emptyState = []
-const oneCardState = [defaultCard]
+const cardIdInState = ({ cards }, cardId) => cards.find(({ id }) => id === cardId)
+
+// Test fixtures
+const emptyState = cardsReducer(undefined, { type: 'blarg' })
+const oneCardState = cardsReducer(undefined, { type: ADD_CARD, card: defaultCard })
+const card1 = { ...defaultCard, id: 1 }
+const card2 = { ...defaultCard, id: 2 }
+const card3 = { ...defaultCard, id: 3 }
+const card4 = { ...defaultCard, id: 4 }
+const fourCardState = cardsReducer(undefined, {
+  type: ADD_LINES_FROM_TEMPLATE,
+  cards: [card1, card2, card3, card4],
+})
 
 describe('cardsReducer', () => {
   it('should produce a valid state object when supplied with an unknown event type', () => {
@@ -91,6 +107,87 @@ describe('cardsReducer', () => {
             [2, 1],
             [1, 0],
           ])
+        })
+      })
+    })
+  })
+  describe('add lines from template', () => {
+    it('should add all given cards to the state', () => {
+      expect(
+        allCardsSelector(
+          mountToState(
+            cardsReducer(emptyState, {
+              type: ADD_LINES_FROM_TEMPLATE,
+              cards: [card1, card2, card3, card4],
+            })
+          )
+        )
+      ).toEqual([card1, card2, card3, card4])
+    })
+  })
+  describe('edit card details', () => {
+    describe('given the default state', () => {
+      it('should produce the default state', () => {
+        expect(
+          cardsReducer(emptyState, {
+            type: EDIT_CARD_DETAILS,
+            id: 0,
+            attributes: {
+              best: true,
+            },
+          })
+        ).toEqual(emptyState)
+      })
+    })
+    describe('given a one card state', () => {
+      describe('and an id for a different card', () => {
+        it('should produce the same one card state', () => {
+          expect(
+            cardsReducer(oneCardState, {
+              type: EDIT_CARD_DETAILS,
+              id: 10,
+              attributes: {
+                best: true,
+              },
+            })
+          ).toEqual(oneCardState)
+        })
+      })
+      describe('and the id of that card', () => {
+        it('should edit that card', () => {
+          expect(
+            allCardsSelector(
+              mountToState(
+                cardsReducer(oneCardState, {
+                  type: EDIT_CARD_DETAILS,
+                  id: 1,
+                  attributes: {
+                    best: true,
+                  },
+                })
+              )
+            )[0]
+          ).toEqual({ ...defaultCard, best: true })
+        })
+      })
+    })
+    describe('given a four card state', () => {
+      describe('and the id of card2', () => {
+        it('should only edit card2', () => {
+          expect(
+            cardIdInState(
+              mountToState(
+                cardsReducer(fourCardState, {
+                  type: EDIT_CARD_DETAILS,
+                  id: 2,
+                  attributes: {
+                    best: true,
+                  },
+                })
+              ),
+              2
+            )
+          ).toEqual({ ...card2, best: true })
         })
       })
     })

--- a/src/app/reducers/__tests__/cards.test.js
+++ b/src/app/reducers/__tests__/cards.test.js
@@ -34,7 +34,7 @@ describe('cardsReducer', () => {
   it('should produce a valid state object when supplied with an unknown event type', () => {
     expect(cardsReducer(emptyState, { type: 'herpa' })).toEqual(emptyState)
   })
-  it('should produce an empty array when given no state object', () => {
+  it('should produce a valid state when given no state object', () => {
     expect(cardsReducer(null, { type: 'derp' })).toEqual(emptyState)
   })
   describe('add card', () => {

--- a/src/app/reducers/__tests__/cards.test.js
+++ b/src/app/reducers/__tests__/cards.test.js
@@ -3,6 +3,7 @@ import {
   ADD_CARD_IN_CHAPTER,
   ADD_LINES_FROM_TEMPLATE,
   EDIT_CARD_DETAILS,
+  EDIT_SCENES_ATTRIBUTE,
 } from '../../constants/ActionTypes'
 import { card as defaultCard } from '../../../../shared/initialState'
 import cardsReducer from '../cards'
@@ -26,6 +27,8 @@ const fourCardState = cardsReducer(undefined, {
   type: ADD_LINES_FROM_TEMPLATE,
   cards: [card1, card2, card3, card4],
 })
+const cardWithStrength = { ...defaultCard, strength: 'You bet!' }
+const strengthState = cardsReducer(undefined, { type: ADD_CARD, card: cardWithStrength })
 
 describe('cardsReducer', () => {
   it('should produce a valid state object when supplied with an unknown event type', () => {
@@ -188,6 +191,62 @@ describe('cardsReducer', () => {
               2
             )
           ).toEqual({ ...card2, best: true })
+        })
+      })
+    })
+  })
+  // TODO: many tests to add.  Adding ones for recent features for
+  // expedience.
+  describe('edit scenes attributes', () => {
+    describe('given an attribute to change', () => {
+      const oldAttribute = { name: 'strength', type: 'text' }
+      const newAttribute = { name: 'do-you-even-lift?', type: 'text' }
+      describe('and the empty state', () => {
+        it('should produce the empty state', () => {
+          expect(
+            cardsReducer(emptyState, {
+              type: EDIT_SCENES_ATTRIBUTE,
+              oldAttribute,
+              newAttribute,
+            })
+          ).toEqual(emptyState)
+        })
+      })
+      describe('and a four card state where no card contains the attribute', () => {
+        it('should add the attribute to those cards', () => {
+          expect(
+            allCardsSelector(
+              mountToState(
+                cardsReducer(fourCardState, {
+                  type: EDIT_SCENES_ATTRIBUTE,
+                  oldAttribute,
+                  newAttribute,
+                })
+              )
+            )
+          ).toEqual(
+            fourCardState.map((card) => ({ ...card, ...{ [newAttribute.name]: undefined } }))
+          )
+        })
+      })
+      describe('and a state where a card has the original attribute', () => {
+        it('should change the name of the attribute', () => {
+          expect(
+            cardIdInState(
+              mountToState(
+                cardsReducer(strengthState, {
+                  type: EDIT_SCENES_ATTRIBUTE,
+                  oldAttribute,
+                  newAttribute,
+                })
+              ),
+              1
+            )
+          ).toEqual({
+            ...cardWithStrength,
+            strength: undefined,
+            'do-you-even-lift?': 'You bet!',
+          })
         })
       })
     })

--- a/src/app/reducers/__tests__/customAttributes.test.js
+++ b/src/app/reducers/__tests__/customAttributes.test.js
@@ -1,0 +1,41 @@
+// Doesn not work because of configuration difficulties in babel.  Ran
+// out of time during the week to finish the implementation.
+
+// import { reducers } from 'pltr/v2'
+// import { allCustomAttributesSelector } from 'app/selectors/customAttributes'
+// import { isEqual } from 'lodash'
+// import { ADD_SCENES_ATTRIBUTE } from '../../constants/ActionTypes'
+
+// const { customAttributes } = reducers
+
+// // Only these functions should change if we change the structure of
+// // the state object.
+// const mountToState = (customAttributes) => ({ customAttributes })
+// const customAttributeInState = ({ customAttributes }, customAttribute) =>
+//   customAttributes.find((x) => isEqual(x, customAttribute))
+
+// // Fixtures
+// const emptyState = customAttributes(undefined, { type: 'TOO_SECRET_TO_TELL_YOU' })
+// const textAttribute1 = { name: 'ranking', type: 'text' }
+
+// describe('customAttributes reducer', () => {
+//   it('should produce a valid state object when supplied with an unknown event type', () => {
+//     expect(customAttributes(emptyState, { type: 'THIS_FEELS_A_BIT_REDUNDANT' })).toEqual(emptyState)
+//   })
+//   it('should produce a valid state when given no state object', () => {
+//     expect(customAttributes(null, { type: 'VERY_STATE' })).toEqual(emptyState)
+//   })
+//   describe('add scenes attribute', () => {
+//     describe('given an empty state', () => {
+//       it('should produce a singleton state containing that attribute', () => {
+//         const allAttributes = allCustomAttributesSelector(
+//           mountToState(
+//             customAttributes(emptyState, { type: ADD_SCENES_ATTRIBUTE, attribute: textAttribute1 })
+//           )
+//         )
+//         expect(allAttributes).toHaveLength(1)
+//         expect(allAttributes).toContain(textAttribute1)
+//       })
+//     })
+//   })
+// })

--- a/src/app/reducers/cards.js
+++ b/src/app/reducers/cards.js
@@ -36,7 +36,9 @@ import { newFileCards } from '../../../shared/newFileState'
 import { card as defaultCard } from '../../../shared/initialState'
 import { nextId } from 'store/newIds'
 
-export default function cards(state, action) {
+const INITIAL_STATE = []
+
+export default function cards(state = INITIAL_STATE, action) {
   let diffObj
   switch (action.type) {
     case ADD_CARD:
@@ -46,7 +48,15 @@ export default function cards(state, action) {
       // add a new card
       // and reorder cards in the chapter
       return [
-        Object.assign({}, defaultCard, action.newCard, { id: nextId(state) }),
+        Object.assign(
+          {},
+          defaultCard,
+          {
+            ...action.newCard,
+            ...(action.reorderIds ? { positionWithinLine: action.reorderIds.indexOf(null) } : {}),
+          },
+          { id: nextId(state) }
+        ),
         ...state.map((card) => {
           const idx = action.reorderIds.indexOf(card.id)
           if (idx != -1) {
@@ -299,6 +309,6 @@ export default function cards(state, action) {
       return newFileCards
 
     default:
-      return state || []
+      return state || INITIAL_STATE
   }
 }


### PR DESCRIPTION
# Add Tests for the Cards Reducer
## Motivation
The cards reducer is not covered by tests and contains some of the apps most important logic.

1. Custom attributes were added to cards without test coverage.
2. We might want to refactor it in due course and tests would help with that.

## Logic Changes Made While Implementing Tests
1. Singleton state produced when adding to an undefined state.  Previously the reducer would error in this case.  We never ran into it because redux initialises the reducer with an unknown event.  It still seems prudent to have a default state value.
2. The position of a card in a chapter is inferred when not supplied.  Previously we relied on the components to provide both the card ordering in `reorderIds` *and* the position of the new card.  The reducer now looks for the position of `null` in `reorderIds` to determine the position of the card in the chapter.