### PR TITLE
Add a Linux target to avoid having to set apple credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pack": "NODE_ENV=production node_modules/.bin/webpack",
     "pack:windows": "node_modules\\.bin\\webpack",
     "dist": "node build/initEnv.js && npm run pack && electron-builder -ml",
+    "dist:linux": "node build/initEnv.js && npm run pack && electron-builder -l",
     "dist:windows": "node build/initEnv.js && npm run pack:windows && electron-builder -w",
     "dist:all": "npm run pack && electron-builder -mw",
     "extract-strings": "format-message extract -o locales/en.json \"bin/**/*.js\" \"src/**/*.js\" \"shared/**/*.js\" \"lib/**/*.js\" && npm run generate-flipped",


### PR DESCRIPTION
# Fix the Build for Linux
Building for both Linux and MacOS means that you need credentials for MacOS apps to build a Linux app.
This branch adds the command: `npm run dist:linux` to build for only Linux.