### PR TITLE
Ignore everything that we can

### DIFF
--- a/bin/new_main.js
+++ b/bin/new_main.js
@@ -44,7 +44,21 @@ if (process.env.NODE_ENV !== 'dev') {
 
 if (process.env.NODE_ENV === 'dev') {
   try {
-    require('electron-reloader')(module, { ignore: ['examples', 'src', '.*#.*#'], debug: true })
+    require('electron-reloader')(module, {
+      ignore: [
+        'examples',
+        'dist',
+        'src',
+        'lib',
+        'build',
+        'icons',
+        'locales',
+        'shared',
+        'test',
+        '.*#.*#',
+      ],
+      debug: true,
+    })
   } catch (e) {
     console.error('Error while instrumenting app for reload.', e)
   }


### PR DESCRIPTION
# Ignore All Irrelevant Directories for Reload
At the moment the project watches everything in the root except for src and a few others.
When you run dist this means that there are thousands of files to watch.
This is also a problem since merging `pltr` into `plottr_electron` because watchers are spawned for all the source files and node modules in that subtree too(!).
We now watch only the root files of `plottr_electron` (I couldn't find a way to avoid that because when I added an exclusion for it it also excluded `bin`) and the `bin` folder for changes.

This makes development lighter on the system.