### PR TITLE
Fix href for rce links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plottr",
-  "version": "2021.2.4",
+  "version": "2021.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8695,6 +8695,28 @@
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
           "dev": true
         },
+        "react-test-renderer": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+          "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-is": "^16.8.6",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -19413,6 +19435,24 @@
         }
       }
     },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
+        }
+      }
+    },
     "react-sticky-table": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-sticky-table/-/react-sticky-table-4.3.1.tgz",
@@ -19422,21 +19462,27 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
+        "react-is": "^17.0.1",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.1"
       },
       "dependencies": {
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
+        },
         "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "version": "0.20.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "node-sass": "^4.14.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
+    "react-test-renderer": "^17.0.1",
     "redux-devtools-cli": "^1.0.0-4",
     "remote-redux-devtools": "^0.5.16",
     "sass-loader": "^7.1.0",

--- a/src/app/components/rce/Element.js
+++ b/src/app/components/rce/Element.js
@@ -34,7 +34,7 @@ const Element = ({ attributes, children, element }) => {
         <a
           {...attributes}
           title={element.url}
-          href="#"
+          href={element.url}
           onClick={() => handleLinkClick(element.url)}
         >
           {children}

--- a/src/app/components/rce/__tests__/links.test.js
+++ b/src/app/components/rce/__tests__/links.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import RichTextEditor from '../RichTextEditor'
+
+describe('links', () => {
+  it('should be rendered with href attributes', () => {
+    const html = mount(
+      <RichTextEditor
+        recentFonts={['Forum']}
+        fonts={['Forum', 'IBM Plex Serif', 'Lato', 'Yellowtail']}
+        text={[
+          {
+            children: [
+              { text: '"A single man in possession of good fortune must be in want of a wife."' },
+            ],
+            type: 'paragraph',
+          },
+          {
+            children: [{ text: 'https://www.google.com' }],
+            type: 'link',
+            url: 'https://www.google.com',
+          },
+        ]}
+      />
+    )
+
+    expect(
+      html.find('a').filterWhere((item) => item.prop('href') === 'https://www.google.com')
+    ).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
# Fix Right Click Copy Link for RCE KAN-31
When a link is rendered, we used `#` for the `href` attribute.
This points the DOM's model of the link at the page in Electron.
We need this because Right Click -> Copy Link uses the DOM element.