### PR TITLE
Kan 116 rce click to focus editor

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,15 @@ path of `/lib`.
     git subtree add --prefix lib/pltr pltr master --squash
 ```
 
+# Debugging Tests
+To debug a test:
+
+1. start the chrome dedicated debugger for node by: running chrome, navigating to `chrome://inspect/`, "Open dedicated DevTools for Node"
+2. add a `debugger` line to the test that you want to debug,
+3. change the path to the test to debug in the script `test:debug` in `package.json` to point at the test that you want to debug.  e.g. `"node --inspect node_modules/.bin/jest --runInBand src/app/components/rce/__tests__/RichTextEditor.test.js"` -> `"node --inspect node_modules/.bin/jest --runInBand <path-to-your-test>"`,
+4. run the script (`npm run test:debug`),
+5. the dedicated debugger should detect the node process and launch a debugging process.
+
 # Copyright Notice
 
 Copyright 2016-2020 Fictional Devices LLC

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "generate-flipped": "node ./locales/build-flipped-locale.js",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand src/app/components/rce/__tests__/RichTextEditor.test.js",
     "start-redux-dev-tools": "redux-devtools --hostname=localhost --port=8000",
     "lint-file": "eslint",
     "lint": "eslint .",

--- a/src/app/components/rce/RichTextEditor.js
+++ b/src/app/components/rce/RichTextEditor.js
@@ -40,6 +40,7 @@ const RichTextEditor = (props) => {
   const renderLeaf = useCallback((props) => <Leaf {...props} />, [])
   const renderElement = useCallback((props) => <Element {...props} />, [])
   const [value, setValue] = useState(null)
+  const [editorWrapperRef, setEditorWrapperRef] = useState(null)
   const key = useRef(Math.random().toString(16))
   const toolbarRef = useRef(null)
   const [showColorPicker, toggleColorPicker] = useState(false)
@@ -107,7 +108,15 @@ const RichTextEditor = (props) => {
         </div>
         <div
           // the firstChild will be the contentEditable dom node
-          ref={(e) => registerEditor(e && e.firstChild)}
+          ref={(e) => {
+            registerEditor(e && e.firstChild)
+            setEditorWrapperRef(e)
+          }}
+          onClick={(event) => {
+            if (!editorWrapperRef) return
+            if (editorWrapperRef.firstChild.contains(event.target)) return
+            editorWrapperRef.firstChild.focus()
+          }}
           className={cx('slate-editor__editor', { darkmode: props.darkMode })}
         >
           <Editable


### PR DESCRIPTION
# Focus on editable region when clicking on editor where there isn't text
This PR fixes KAN-116:
 - open a card dialog,
 - click anywhere on the editable region which doesn't yet contain text,
 - the editor isn't focus for text insertion.

## Fix
Use the ref to the editor's editable dom node to focus the editor's first child element when we detect a click which isn't contained by the first child.

## Tests
I tried to implement a test for this problem, but ran into problems.
There are discussions about doing this properly, and the methods of testing appear to work for some people and not others.
I tried to detect when the document's current focus changes after simulating a click.
It appears to not have worked.
I feel like this might be too flaky to add as a test at this time.

This is the non-working test.
Suggestions for a better test welcome!
```javascript
import React from 'react'
import { mount } from 'enzyme'

import RichTextEditor from '../RichTextEditor'

describe('RichTextEditor', () => {
  describe('given a rendered editor', () => {
    describe('when you click on the top line of the editor', () => {
      it('should focus that line', async () => {
        const html = mount(
          <RichTextEditor
            recentFonts={['Forum']}
            fonts={['Forum', 'IBM Plex Serif', 'Lato', 'Yellowtail']}
            text={[
              {
                children: [
                  {
                    text: '"A single man in possession of good fortune must be in want of a wife."',
                  },
                ],
                type: 'paragraph',
              },
              {
                children: [{ text: 'https://www.google.com' }],
                type: 'link',
                url: 'https://www.google.com',
              },
            ]}
          />
        )
        console.log(document.activeElement.className)
        const editorElement = html.find('.slate-editor__editor div').instance().click()
        const focusedElement = document.activeElement
        console.log(focusedElement.className)

        const focused = await new Promise((resolve, reject) => {
          setTimeout(() => {
            editorElement.is(':focus')
          }, 500)
        })

        expect(focused).toEqual(true)
      })
    })
    describe('when you click on the bottom region of the editor, (outside of text)', () => {
      it('should focus the editable region of the editor', () => {
        const html = mount(
          <RichTextEditor
            recentFonts={['Forum']}
            fonts={['Forum', 'IBM Plex Serif', 'Lato', 'Yellowtail']}
            text={[
              {
                children: [
                  {
                    text: '"A single man in possession of good fortune must be in want of a wife."',
                  },
                ],
                type: 'paragraph',
              },
              {
                children: [{ text: 'https://www.google.com' }],
                type: 'link',
                url: 'https://www.google.com',
              },
            ]}
          />
        )

        const editorElement = html.find('.slate-editor__editor').simulate('click')
        const focusedElement = document.activeElement

        expect(editorElement.matchesElement(focusedElement)).toEqual(true)
      })
    })
  })
})
```