### PR TITLE
Hack: focus the form element when it's clicked

### DIFF
--- a/src/app/components/images/ImagePicker.js
+++ b/src/app/components/images/ImagePicker.js
@@ -179,7 +179,14 @@ class ImagePicker extends Component {
               <ControlLabel>
                 <h6>{i18n('Enter the URL of the link:')}</h6>
               </ControlLabel>
-              <FormControl placeholder={i18n('URL')} type="text" onChange={this.getFromURL} />
+              <FormControl
+                onClick={(event) => {
+                  event.target.focus()
+                }}
+                placeholder={i18n('URL')}
+                type="text"
+                onChange={this.getFromURL}
+              />
             </FormGroup>
             {this.state.loading ? <Spinner /> : null}
           </div>


### PR DESCRIPTION
# Fixes KAN-117
This is a hack.  It fixes the problem in the short term.  I recommend that more time is provisioned to investigate further.

## Description
If the user opens a card dialogue and then opens the image picker, then the RCE opens another modal on top of the card modal.
If the user goes to the image from URL tab then the input field is non-interactive.

# Discussion
I suspect that focus is actually being stolen by the modal which the image picker model is on top of.
There's a mousedown event which appears to steal focus (if I delete it the event handler from the developer tools then focus works as expected and the user can enter text into the input field).
I recommend that this hack be removed when we track down where the mousedown event comes from.