### PR TITLE
Remove lines, beats and cards associated to deleted book

### DIFF
--- a/lib/pltr/v2/reducers/beats.js
+++ b/lib/pltr/v2/reducers/beats.js
@@ -11,6 +11,7 @@ import {
   REORDER_CARDS_IN_BEAT,
   RESET,
   RESET_TIMELINE,
+  DELETE_BOOK,
 } from '../constants/ActionTypes'
 import { beat as defaultBeat } from '../store/initialState'
 import { newFileBeats } from '../store/newFileState'
@@ -53,6 +54,9 @@ export default function beats(state = INITIAL_STATE, action) {
       return state.map((beat) =>
         beat.id == action.id ? Object.assign({}, beat, { title: action.title }) : beat
       )
+
+    case DELETE_BOOK:
+      return state.filter(({ bookId }) => bookId !== action.id)
 
     case DELETE_BEAT: {
       const [delBook, delNotBook] = partition(state, (beat) => beat.bookId == actionBookId)

--- a/lib/pltr/v2/reducers/cards.js
+++ b/lib/pltr/v2/reducers/cards.js
@@ -30,6 +30,7 @@ import {
   REORDER_CARDS_WITHIN_LINE,
   RESET,
   RESET_TIMELINE,
+  DELETE_BOOK,
 } from '../constants/ActionTypes'
 import { newFileCards } from '../store/newFileState'
 import { card as defaultCard } from '../store/initialState'
@@ -144,6 +145,9 @@ export default function cards(state = INITIAL_STATE, action) {
 
         return Object.assign({}, card, { positionInBeat: 0 })
       })
+
+    case DELETE_BOOK:
+      return state.filter(({ bookId }) => bookId !== action.id)
 
     case DELETE_CARD:
       return state.filter((card) => card.id !== action.id)

--- a/lib/pltr/v2/reducers/lines.js
+++ b/lib/pltr/v2/reducers/lines.js
@@ -18,6 +18,7 @@ import {
   FILE_LOADED,
   NEW_FILE,
   RESET,
+  DELETE_BOOK,
 } from '../constants/ActionTypes'
 import { line } from '../store/initialState'
 import { newFileLines } from '../store/newFileState'
@@ -87,6 +88,9 @@ export default function lines(state = initialState, action) {
       return state.map((l) =>
         l.id === action.id ? Object.assign({}, l, { color: action.color }) : l
       )
+
+    case DELETE_BOOK:
+      return state.filter(({ bookId }) => bookId !== action.id)
 
     case DELETE_LINE:
       return state.filter((l) => l.id !== action.id)


### PR DESCRIPTION
# Deleting a book leaves behind cards, beats and lines
I'm not sure whether the behaviour outlined in the heading is intended.
If `DELETE_BOOK` is supposed to delete a book along with it's associated data, then this PR accomplishes that.