### PR TITLE
Special case applying a template for a line rather than the project

### DIFF
--- a/lib/pltr/v2/template/index.js
+++ b/lib/pltr/v2/template/index.js
@@ -1,8 +1,9 @@
 import migrateIfNeeded from '../migrator/migration_manager'
 import { emptyFile } from '../store/newFileState'
 
-export const projectFromTemplate = (template, appVersion, projectTitle, callback) => {
+const fromTemplate = (forLines) => (template, appVersion, projectTitle, callback) => {
   const emptyPlottrFile = emptyFile(projectTitle, appVersion)
+  if (forLines) emptyPlottrFile.lines = []
   const version = template.version || guessVersion(template.templateData)
   if (!version) {
     callback(new Error(`Couldn't determine version of template: ${template.name}`))
@@ -24,6 +25,10 @@ export const projectFromTemplate = (template, appVersion, projectTitle, callback
     }
   )
 }
+
+export const projectFromTemplate = fromTemplate(false)
+
+export const lineFromTemplate = fromTemplate(true)
 
 /* This function is useful for custom templates created from 2021.2.8
  * backwards because in those versions we didn't attach an version to

--- a/src/common/components/templates/PlotlineTemplateDetails.js
+++ b/src/common/components/templates/PlotlineTemplateDetails.js
@@ -6,7 +6,7 @@ import { template } from 'pltr/v2'
 import { remote } from 'electron'
 import { isEmpty } from 'lodash'
 
-const { projectFromTemplate } = template
+const { lineFromTemplate } = template
 const { app } = remote
 
 export default class PlotlineTemplateDetails extends Component {
@@ -26,7 +26,7 @@ export default class PlotlineTemplateDetails extends Component {
   }
 
   migrateTemplate = () => {
-    projectFromTemplate(this.props.template, app.getVersion(), '', (error, template) => {
+    lineFromTemplate(this.props.template, app.getVersion(), '', (error, template) => {
       if (error) {
         // Allow the top level ErrorBoundary to handle the error
         throw new Error(error)

--- a/src/common/components/templates/TemplatePicker.js
+++ b/src/common/components/templates/TemplatePicker.js
@@ -23,7 +23,7 @@ import { template } from 'pltr/v2'
 
 export const testIds = getTestIds()
 
-const { projectFromTemplate } = template
+const { lineFromTemplate, projectFromTemplate } = template
 const modalStyles = { content: { width: '50%', marginLeft: '25%' } }
 const win = remote.getCurrentWindow()
 const { app } = remote
@@ -115,7 +115,8 @@ export default class TemplatePicker extends Component {
     const selectedTemplate = this.selectedTemplate()
     const { type } = selectedTemplate
     if (type === 'project' || type === 'plotlines') {
-      projectFromTemplate(selectedTemplate, app.getVersion(), '', (error, template) => {
+      const migrator = this.props.newProject ? projectFromTemplate : lineFromTemplate
+      migrator(selectedTemplate, app.getVersion(), '', (error, template) => {
         if (error) {
           // Let the ErrorBoundary handle the error
           throw new Error(error)
@@ -335,6 +336,7 @@ export default class TemplatePicker extends Component {
   }
 
   static propTypes = {
+    newProject: PropTypes.bool,
     modal: PropTypes.bool.isRequired,
     close: PropTypes.func,
     onChooseTemplate: PropTypes.func.isRequired,

--- a/src/dashboard/components/files/FilesHome.js
+++ b/src/dashboard/components/files/FilesHome.js
@@ -41,6 +41,7 @@ export default function FilesHome(props) {
     case 'templates':
       body = (
         <TemplatePicker
+          newProject
           modal={false}
           type={['custom', 'project', 'plotlines']}
           onChooseTemplate={createWithTemplate}


### PR DESCRIPTION
# Don't use Empty File Lines When Migrating Templates to Apply to Timelines
Previous versions of `plottr` supported exporting without a line and applied a template by creating a line with a title that equalled the template's title.
The problem with doing this is that it's hard to migrate partial templates.
A previous commit ensured that templates are created with a line.
Partial templates could still exist in user's templates files.
So this PR supports that case by special-casing the application of templates to new timelines.