### PR TITLE
Depend on plottr_locales instead of format-message from pltr

### DIFF
--- a/lib/pltr/package.json
+++ b/lib/pltr/package.json
@@ -26,6 +26,6 @@
     "tinycolor2": "^1.4.2"
   },
   "peerDependencies": {
-    "format-message": "^6.2.1"
+    "plottr_locales": "0.0.1"
   }
 }


### PR DESCRIPTION
# Dowstream Changes from `pltr`
Changes `plottr_locales` to a peer dependency in `pltr`.