### PR TITLE
Always allow beats to become manually sorted

### DIFF
--- a/lib/pltr/v2/reducers/beats.js
+++ b/lib/pltr/v2/reducers/beats.js
@@ -74,9 +74,7 @@ export default function beats(state = INITIAL_STATE, action) {
 
     case REORDER_CARDS_IN_BEAT:
       return state.map((beat) =>
-        beat.id == action.beatId && action.isSeries
-          ? Object.assign({}, beat, { autoOutlineSort: false })
-          : beat
+        beat.id == action.beatId ? Object.assign({}, beat, { autoOutlineSort: false }) : beat
       )
 
     case AUTO_SORT_BEAT:


### PR DESCRIPTION
The problem seems to have originated in the refactoring to merge beats and chapters.
Beats could only be manually sorted if they were associated with a series.
Now beats are associated with series and books so the check is incorrect.