### PR TITLE
Fix delete beat bug

### DIFF
--- a/lib/pltr/v2/helpers/__tests__/lists.test.js
+++ b/lib/pltr/v2/helpers/__tests__/lists.test.js
@@ -7,4 +7,34 @@ describe('closeGap', () => {
       expect(closeGap(EMPTY_LIST)).toEqual(EMPTY_LIST)
     })
   })
+  describe('given a list with one "beat"', () => {
+    const SINGLETON_LIST = [{ id: 0, position: 0 }]
+    it('should produce that same list', () => {
+      expect(closeGap(SINGLETON_LIST)).toEqual(SINGLETON_LIST)
+    })
+  })
+  describe('given a list with two "beats" where the beats are sorted', () => {
+    const TWO_ELEMENT_LIST = [
+      { id: 0, position: 1 },
+      { id: 1, position: 4 },
+    ]
+    it('should produce those beats with the correct positions', () => {
+      expect(closeGap(TWO_ELEMENT_LIST)).toEqual([
+        { id: 0, position: 0 },
+        { id: 1, position: 1 },
+      ])
+    })
+  })
+  describe('given a list with two "beats" where the beats are not sorted', () => {
+    const TWO_ELEMENT_LIST = [
+      { id: 1, position: 4 },
+      { id: 0, position: 1 },
+    ]
+    it('should produce those beats with the correct positions', () => {
+      expect(closeGap(TWO_ELEMENT_LIST)).toEqual([
+        { id: 0, position: 0 },
+        { id: 1, position: 1 },
+      ])
+    })
+  })
 })

--- a/lib/pltr/v2/helpers/__tests__/lists.test.js
+++ b/lib/pltr/v2/helpers/__tests__/lists.test.js
@@ -1,0 +1,10 @@
+import { closeGap } from '../lists'
+
+describe('closeGap', () => {
+  describe('given the empty list', () => {
+    const EMPTY_LIST = []
+    it('should produce the empty list', () => {
+      expect(closeGap(EMPTY_LIST)).toEqual(EMPTY_LIST)
+    })
+  })
+})

--- a/lib/pltr/v2/helpers/lists.js
+++ b/lib/pltr/v2/helpers/lists.js
@@ -28,6 +28,10 @@ export function positionReset(items) {
     })
 }
 
+export function closeGap(items) {
+  return positionReset(items)
+}
+
 export function nextPositionInBook(items, bookId) {
   return (
     items

--- a/lib/pltr/v2/helpers/lists.js
+++ b/lib/pltr/v2/helpers/lists.js
@@ -1,3 +1,5 @@
+import { sortBy } from 'lodash'
+
 export function reorderList(originalPosition, newPosition, list) {
   const newList = [...list]
   const [removed] = newList.splice(newPosition, 1)
@@ -29,7 +31,10 @@ export function positionReset(items) {
 }
 
 export function closeGap(items) {
-  return positionReset(items)
+  return sortBy(items, 'position').map((item, idx) => ({
+    ...item,
+    position: idx,
+  }))
 }
 
 export function nextPositionInBook(items, bookId) {

--- a/lib/pltr/v2/reducers/beats.js
+++ b/lib/pltr/v2/reducers/beats.js
@@ -16,7 +16,7 @@ import {
 import { beat as defaultBeat } from '../store/initialState'
 import { newFileBeats } from '../store/newFileState'
 import { nextId } from '../store/newIds'
-import { nextPositionInBook, positionReset } from '../helpers/lists'
+import { nextPositionInBook, positionReset, closeGap } from '../helpers/lists'
 import { associateWithBroadestScope } from '../helpers/lines'
 import { sortBy, partition } from 'lodash'
 
@@ -26,6 +26,14 @@ import { sortBy, partition } from 'lodash'
 //  - "series": String literal,
 
 const INITIAL_STATE = [defaultBeat]
+
+export function deleteBeat(beats, beatId, bookId) {
+  const [delBook, delNotBook] = partition(beats, (beat) => beat.bookId == bookId)
+  return [
+    ...delNotBook,
+    ...closeGap(delBook.filter((beat) => beat.id != beatId)), // assumes they are sorted
+  ]
+}
 
 export default function beats(state = INITIAL_STATE, action) {
   const actionBookId = associateWithBroadestScope(action.bookId)
@@ -59,11 +67,7 @@ export default function beats(state = INITIAL_STATE, action) {
       return state.filter(({ bookId }) => bookId !== action.id)
 
     case DELETE_BEAT: {
-      const [delBook, delNotBook] = partition(state, (beat) => beat.bookId == actionBookId)
-      return [
-        ...delNotBook,
-        ...positionReset(delBook.filter((beat) => beat.id != action.id)), // assumes they are sorted
-      ]
+      return deleteBeat(state, action.id, actionBookId)
     }
 
     case REORDER_BEATS:

--- a/lib/pltr/v2/reducers/beats.js
+++ b/lib/pltr/v2/reducers/beats.js
@@ -29,10 +29,7 @@ const INITIAL_STATE = [defaultBeat]
 
 export function deleteBeat(beats, beatId, bookId) {
   const [delBook, delNotBook] = partition(beats, (beat) => beat.bookId == bookId)
-  return [
-    ...delNotBook,
-    ...closeGap(delBook.filter((beat) => beat.id != beatId)), // assumes they are sorted
-  ]
+  return [...delNotBook, ...closeGap(delBook.filter((beat) => beat.id != beatId))]
 }
 
 export default function beats(state = INITIAL_STATE, action) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "extract-strings": "format-message extract -o lib/plottr_locales/en.json \"bin/**/*.js\" \"src/**/*.js\" \"shared/**/*.js\" \"lib/**/*.js\" && npm run generate-flipped",
     "generate-flipped": "node ./lib/plottr_locales/build-flipped-locale.js",
     "test": "jest '(src.*)|(lib.*)'",
-    "test:watch": "jest '(src.*)|(lib.*)' --watch",
+    "test:watch": "jest \"(src.*)|(lib.*)\" --watch",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand src/app/components/rce/__tests__/RichTextEditor.test.js",
     "test:integration": "jest test/integration",
     "start-redux-dev-tools": "redux-devtools --hostname=localhost --port=8000",


### PR DESCRIPTION
# Problem Description
After adding one or more beats to the timeline and then deleting a beat, the beats are repositioned in the wrong order.

# Investigation
This happens because the old `DELETE_BEAT` action ran a `positionReset` on the beats after filtering out the deleted beat.
`positionReset` changes the order of the beats to the order that they appear in the array rather than their `position`s(!)
When a beat is added to the timeline, we prepend it.
So, when we delete a beat, the beats aren't sorted, and the beats with correct `position`s but positions in the array of beats that don't correspond to their `position`s are placed wherever they are in the array.

# Fix Details
First, sort the beats before re-ordering.
Note: The `positionReset` function is used elsewhere to set the ordering of beats to a given ordering, so we don't want to change it(!)

# Final Notes
This problem won't exist when `project-hierarchy` is merged, *and* its data structure for beats does a better job of enforcing domain rules like this one.