### PR TITLE
kan-103 fix error in outline view when timeline is empty

### DIFF
--- a/src/app/components/outline/OutlineView.js
+++ b/src/app/components/outline/OutlineView.js
@@ -123,8 +123,9 @@ class OutlineView extends Component {
   }
 
   renderBeats(cardMapping) {
-    return this.props.beats.map((beat, idx) => {
-      if (this.state.firstRender && idx > 2) return null
+    const { beats } = this.props
+    return !!beats.length && beats.map((beat, idx) => {
+      if ((this.state.firstRender && idx > 2)) return null
       return (
         <ErrorBoundary key={beat.id}>
           <BeatView
@@ -158,10 +159,11 @@ class OutlineView extends Component {
   }
 
   render() {
+    const { beats } = this.props
     return (
       <div className="container-with-sub-nav">
         {this.renderSubNav()}
-        {this.renderBody()}
+        {!!beats.length && this.renderBody()}
       </div>
     )
   }


### PR DESCRIPTION
https://user-images.githubusercontent.com/19387007/113133355-21625c80-9252-11eb-88c6-2970e157e0fa.mp4

I left it blank. I'm not sure what's a better placeholder for empty outline 
Task link: https://app.ora.pm/p/4c35de9a18594ccbaee3377dcc546780?v=0&t=k&c=c032929d1805481cbbe1a4331d845101