### PR TITLE
kan-265 move Notes column before the Characters

### DIFF
--- a/src/app/components/export/ExportBody.js
+++ b/src/app/components/export/ExportBody.js
@@ -31,9 +31,9 @@ export default function ExportBody({ type, onChange }) {
         <GeneralOptions type={type} options={options.general} updateOptions={updateOptions} />
       ) : null}
       <OutlineOptions type={type} options={options.outline} updateOptions={updateOptions} />
+      <NoteOptions type={type} options={options.notes} updateOptions={updateOptions} />
       <CharacterOptions type={type} options={options.characters} updateOptions={updateOptions} />
       <PlaceOptions type={type} options={options.places} updateOptions={updateOptions} />
-      <NoteOptions type={type} options={options.notes} updateOptions={updateOptions} />
     </div>
   )
 }


### PR DESCRIPTION
move Notes column before the Characters column 
![Screenshot from 2021-04-01 01-35-00](https://user-images.githubusercontent.com/19387007/113186729-9a7da600-928a-11eb-9dc9-aa6d82641e52.png)
