### PR TITLE
Use different branch for templates on staging re hierarchy

### DIFF
--- a/src/dashboard/components/options/OptionsHome.js
+++ b/src/dashboard/components/options/OptionsHome.js
@@ -7,6 +7,7 @@ import { FormControl, FormGroup, ControlLabel, HelpBlock } from 'react-bootstrap
 import { BACKUP_BASE_PATH } from '../../../common/utils/config_paths'
 import LanguagePicker from '../../../common/components/LanguagePicker'
 import DarkOptionsSelect from './DarkOptionsSelect'
+import TemplateFetcher from '../../utils/template_fetcher'
 
 export default function OptionsHome(props) {
   const [settings, _, saveSetting] = useSettingsInfo()
@@ -38,6 +39,10 @@ export default function OptionsHome(props) {
     const newValue = !settings.user.beatHierarchy
     saveSetting('user.beatHierarchy', newValue)
     ipcRenderer.send('pls-update-beat-hierarchy-flag', newValue)
+    // Templates are different for the beat hierarchy feature.
+    // FIXME: when we un-beta this feature then this can be removed safely.
+    // Also See: TemplateFetcher.manifestReq()
+    TemplateFetcher.fetch(true)
   }
 
   return (

--- a/src/dashboard/utils/template_fetcher.js
+++ b/src/dashboard/utils/template_fetcher.js
@@ -50,7 +50,7 @@ class TemplateFetcher {
     return {
       // FIXME: when the beat hierarchy becomes non-beta then we can
       // just use manifest URL.
-      url: SETTINGS.store.user.beatHierarchy ? betaManifestURL : manifestURL,
+      url: SETTINGS.get('user.beatHierarchy') ? betaManifestURL : manifestURL,
       json: true,
     }
   }

--- a/src/dashboard/utils/template_fetcher.js
+++ b/src/dashboard/utils/template_fetcher.js
@@ -11,7 +11,7 @@ import { is } from 'electron-util'
 
 const OLD_TEMPLATES_ROOT = 'templates'
 const manifestURL =
-  'https://raw.githubusercontent.com/Plotinator/plottr_templates/master/v2/manifest.json'
+  'https://raw.githubusercontent.com/Plotinator/plottr_templates/project-hierarchy/v2/manifest.json'
 
 class TemplateFetcher {
   constructor(props) {


### PR DESCRIPTION
# Use Different Templates For Beta On/Off
## Motivation
 - We want to leave the user experience unchanged when the user turns the beta off.
 - While the beta is on, we want to leverage the new structure to create richer templates (e.g. templates with acts will have Acts on the timeline).

## Mechanics
Every time that the user changes the beta feature, we force a fetch and update of templates.

## See Also
New templates fetched from: https://github.com/Plotinator/plottr_templates/pull/3