### PR TITLE
Use the old names for beat title cells when hierarchy is off

### DIFF
--- a/lib/pltr/v2/helpers/beats.js
+++ b/lib/pltr/v2/helpers/beats.js
@@ -8,30 +8,58 @@ export function beatOneIsPrologue(sortedBookBeats) {
   return sortedBookBeats[0].title == i18n('Prologue')
 }
 
-export function beatName(beats, beat, sortedHierarchyLevels) {
+export function beatName(beats, beat, sortedHierarchyLevels, hierarchyEnabled, isSeries) {
+  if (!hierarchyEnabled) {
+    if (isSeries) {
+      return 'Beat'
+    } else {
+      return 'Chapter'
+    }
+  }
+
   const depth = tree.depth(beats, beat.id)
   const hierarchyLevel = sortedHierarchyLevels[depth]
   return (hierarchyLevel && hierarchyLevel.name) || `Level-${depth}`
 }
 
-export function beatTitle(beats, beat, sortedHierarchyLevels, offset) {
+export function beatTitle(beats, beat, sortedHierarchyLevels, offset, hierarchyEnabled, isSeries) {
   return beat.title == 'auto'
-    ? i18n(`${beatName(beats, beat, sortedHierarchyLevels)} {number}`, {
+    ? i18n(`${beatName(beats, beat, sortedHierarchyLevels, hierarchyEnabled, isSeries)} {number}`, {
         number: beat.position + offset + 1,
       })
     : beat.title
 }
 
-export function editingBeatLabel(beats, beat, sortedHierarchyLevels, offset) {
-  return i18n(`${beatName(beats, beat, sortedHierarchyLevels)} {number} title`, {
-    number: beat.position + offset + 1,
-  })
+export function editingBeatLabel(
+  beats,
+  beat,
+  sortedHierarchyLevels,
+  offset,
+  hierarchyEnabled,
+  isSeries
+) {
+  return i18n(
+    `${beatName(beats, beat, sortedHierarchyLevels, hierarchyEnabled, isSeries)} {number} title`,
+    {
+      number: beat.position + offset + 1,
+    }
+  )
 }
 
-export function beatPositionTitle(beats, beat, sortedHierarchyLevels, offset) {
-  return i18n(`${beatName(beats, beat, sortedHierarchyLevels)} {number}`, {
-    number: beat.position + offset + 1,
-  })
+export function beatPositionTitle(
+  beats,
+  beat,
+  sortedHierarchyLevels,
+  offset,
+  hierarchyEnabled,
+  isSeries
+) {
+  return i18n(
+    `${beatName(beats, beat, sortedHierarchyLevels, hierarchyEnabled, isSeries)} {number}`,
+    {
+      number: beat.position + offset + 1,
+    }
+  )
 }
 
 export function insertBeat(position, beats, newId, bookId) {

--- a/lib/pltr/v2/selectors/beats.js
+++ b/lib/pltr/v2/selectors/beats.js
@@ -1,6 +1,6 @@
 import { sortBy } from 'lodash'
 import { createSelector } from 'reselect'
-import { currentTimelineSelector } from './ui'
+import { currentTimelineSelector, isSeriesSelector } from './ui'
 import { maxDepth, nextId } from '../helpers/beats'
 import { beatTitle, beatOneIsPrologue } from '../helpers/beats'
 import { findNode, children, depth } from '../reducers/tree'
@@ -85,9 +85,11 @@ export const makeBeatTitleSelector = () =>
     beatIdSelector,
     sortedHierarchyLevels,
     positionOffsetSelector,
-    (beats, beatId, hierarchyLevels, positionOffset) => {
+    beatHierarchyIsOn,
+    isSeriesSelector,
+    (beats, beatId, hierarchyLevels, positionOffset, hierarchyEnabled, isSeries) => {
       const beat = findNode(beats, beatId)
       if (!beat) return ''
-      return beatTitle(beats, beat, hierarchyLevels, positionOffset)
+      return beatTitle(beats, beat, hierarchyLevels, positionOffset, hierarchyEnabled, isSeries)
     }
   )

--- a/src/app/components/outline/BeatView.js
+++ b/src/app/components/outline/BeatView.js
@@ -14,6 +14,8 @@ const {
   positionOffsetSelector,
   sortedLinesByBookSelector,
   sortedHierarchyLevels,
+  beatHierarchyIsOn,
+  isSeriesSelector,
 } = selectors
 
 const BeatActions = actions.beat
@@ -116,6 +118,8 @@ class BeatView extends Component {
       cards,
       activeFilter,
       positionOffset,
+      hierarchyEnabled,
+      isSeries,
     } = this.props
     if (activeFilter && !cards.length) return null
 
@@ -129,7 +133,7 @@ class BeatView extends Component {
       >
         <div>
           <h3 id={`beat-${beat.id}`} className={klasses}>
-            {beatTitle(beats, beat, hierarchyLevels, positionOffset)}
+            {beatTitle(beats, beat, hierarchyLevels, positionOffset, hierarchyEnabled, isSeries)}
             {this.renderManualSort()}
           </h3>
           {this.renderCards()}
@@ -151,6 +155,8 @@ BeatView.propTypes = {
   positionOffset: PropTypes.number.isRequired,
   beatActions: PropTypes.object,
   actions: PropTypes.object,
+  hierarchyEnabled: PropTypes.bool,
+  isSeries: PropTypes.bool,
 }
 
 function mapStateToProps(state) {
@@ -160,6 +166,8 @@ function mapStateToProps(state) {
     hierarchyLevels: sortedHierarchyLevels(state.present),
     lines: sortedLinesByBookSelector(state.present),
     positionOffset: positionOffsetSelector(state.present),
+    hierarchyEnabled: beatHierarchyIsOn(state),
+    isSeries: isSeriesSelector(state),
   }
 }
 

--- a/src/app/components/outline/MiniBeat.js
+++ b/src/app/components/outline/MiniBeat.js
@@ -19,6 +19,8 @@ function MiniBeat(props) {
     linesById,
     sortedLines,
     positionOffset,
+    hierarchyEnabled,
+    isSeries,
   } = props
   const [sortedCards, setSortedCards] = useState([])
   // https://www.smashingmagazine.com/2020/02/html-drag-drop-api-react/
@@ -106,7 +108,9 @@ function MiniBeat(props) {
     >
       <span>
         <span className="accented-text">{`${idx + 1}.  `}</span>
-        <span>{beatTitle(beats, beat, hierarchyLevels, positionOffset)}</span>
+        <span>
+          {beatTitle(beats, beat, hierarchyLevels, positionOffset, hierarchyEnabled, isSeries)}
+        </span>
       </span>
       <div className="outline__minimap__dots">{renderCardDots()}</div>
     </div>
@@ -125,6 +129,8 @@ MiniBeat.propTypes = {
   positionOffset: PropTypes.number.isRequired,
   reorderCardsWithinLine: PropTypes.func.isRequired,
   reorderCardsInBeat: PropTypes.func.isRequired,
+  hierarchyEnabled: PropTypes.bool,
+  isSeries: PropTypes.bool,
 }
 
 export default MiniBeat

--- a/src/app/components/outline/miniMap.js
+++ b/src/app/components/outline/miniMap.js
@@ -17,6 +17,8 @@ const {
   positionOffsetSelector,
   sortedLinesByBookSelector,
   sortedHierarchyLevels,
+  beatHierarchyIsOn,
+  isSeriesSelector,
 } = selectors
 
 const targetPosition = 115
@@ -61,6 +63,8 @@ class MiniMap extends Component {
       actions,
       ui,
       hierarchyLevels,
+      hierarchyEnabled,
+      isSeries,
     } = this.props
     const linesById = keyBy(lines, 'id')
     return beats.map((beat, idx) => {
@@ -86,6 +90,8 @@ class MiniMap extends Component {
             positionOffset={positionOffset}
             reorderCardsWithinLine={actions.reorderCardsWithinLine}
             reorderCardsInBeat={actions.reorderCardsInBeat}
+            hierarchyEnabled={hierarchyEnabled}
+            isSeries={isSeries}
           />
         </NavItem>
       )
@@ -137,6 +143,8 @@ MiniMap.propTypes = {
   positionOffset: PropTypes.number.isRequired,
   actions: PropTypes.object,
   handleActive: PropTypes.func,
+  hierarchyEnabled: PropTypes.bool,
+  isSeries: PropTypes.bool,
 }
 
 function mapStateToProps(state) {
@@ -147,6 +155,8 @@ function mapStateToProps(state) {
     lines: sortedLinesByBookSelector(state.present),
     ui: state.present.ui,
     positionOffset: positionOffsetSelector(state.present),
+    hierarchyEnabled: beatHierarchyIsOn(state),
+    isSeries: isSeriesSelector(state),
   }
 }
 

--- a/src/app/components/timeline/BeatTitleCell.js
+++ b/src/app/components/timeline/BeatTitleCell.js
@@ -232,13 +232,28 @@ class BeatTitleCell extends PureComponent {
   }
 
   renderTitle() {
-    const { beats, beat, beatTitle, hierarchyLevels, positionOffset } = this.props
+    const {
+      beats,
+      beat,
+      beatTitle,
+      hierarchyLevels,
+      positionOffset,
+      hierarchyEnabled,
+      isSeries,
+    } = this.props
     if (!this.state.editing) return <span>{truncateTitle(beatTitle, 50)}</span>
 
     return (
       <FormGroup>
         <ControlLabel>
-          {editingBeatLabel(beats, beat, hierarchyLevels, positionOffset)}
+          {editingBeatLabel(
+            beats,
+            beat,
+            hierarchyLevels,
+            positionOffset,
+            hierarchyEnabled,
+            isSeries
+          )}
         </ControlLabel>
         <FormControl
           type="text"
@@ -266,6 +281,8 @@ class BeatTitleCell extends PureComponent {
       beatTitle,
       isSmall,
       isMedium,
+      hierarchyEnabled,
+      isSeries,
     } = this.props
     const { hovering, inDropZone } = this.state
     const innerKlass = cx(orientedClassName('beat__body', ui.orientation), {
@@ -296,7 +313,14 @@ class BeatTitleCell extends PureComponent {
           {this.renderDelete()}
           {this.renderEditInput()}
           <div
-            title={beatPositionTitle(beats, beat, hierarchyLevels, positionOffset)}
+            title={beatPositionTitle(
+              beats,
+              beat,
+              hierarchyLevels,
+              positionOffset,
+              hierarchyEnabled,
+              isSeries
+            )}
             onClick={hovering ? this.stopHovering : this.startHovering}
             draggable
             onDragStart={this.handleDragStart}
@@ -311,7 +335,14 @@ class BeatTitleCell extends PureComponent {
         <Cell className="beat-table-cell">
           <div
             className={beatKlass}
-            title={beatPositionTitle(beats, beat, hierarchyLevels, positionOffset)}
+            title={beatPositionTitle(
+              beats,
+              beat,
+              hierarchyLevels,
+              positionOffset,
+              hierarchyEnabled,
+              isSeries
+            )}
             onMouseEnter={this.startHovering}
             onMouseLeave={this.stopHovering}
             onDrop={this.handleDrop}
@@ -355,6 +386,8 @@ BeatTitleCell.propTypes = {
   positionOffset: PropTypes.number.isRequired,
   isSmall: PropTypes.bool.isRequired,
   isMedium: PropTypes.bool.isRequired,
+  hierarchyEnabled: PropTypes.bool.isRequired,
+  isSeries: PropTypes.bool.isRequired,
 }
 
 const makeMapState = (state) => {

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -341,11 +341,21 @@ class CardDialog extends Component {
   }
 
   renderBeatItems() {
-    const { beats, beatTree, hierarchyLevels, positionOffset } = this.props
+    const {
+      beats,
+      beatTree,
+      hierarchyLevels,
+      positionOffset,
+      hierarchyEnabled,
+      isSeries,
+    } = this.props
     return beats.map((beat) => {
       return (
         <MenuItem key={beat.id} onSelect={() => this.changeBeat(beat.id)}>
-          {truncateTitle(beatTitle(beatTree, beat, hierarchyLevels, positionOffset), 50)}
+          {truncateTitle(
+            beatTitle(beatTree, beat, hierarchyLevels, positionOffset, hierarchyEnabled, isSeries),
+            50
+          )}
         </MenuItem>
       )
     })
@@ -431,7 +441,15 @@ class CardDialog extends Component {
     const lineDropdownID = 'select-line'
     const beatDropdownID = 'select-beat'
 
-    const { hierarchyLevels, positionOffset, isSeries, card, ui, beatTree } = this.props
+    const {
+      hierarchyLevels,
+      positionOffset,
+      isSeries,
+      card,
+      ui,
+      beatTree,
+      hierarchyEnabled,
+    } = this.props
 
     let labelText = i18n('Chapter')
     let bookDropDown = null
@@ -443,7 +461,9 @@ class CardDialog extends Component {
       beatTree,
       this.getCurrentBeat(),
       hierarchyLevels,
-      positionOffset
+      positionOffset,
+      hierarchyEnabled,
+      isSeries
     )
     const darkened = card.color ? tinycolor(card.color).darken().toHslString() : null
     const borderColor = card.color ? darkened : 'hsl(211, 27%, 70%)' // $gray-6
@@ -633,6 +653,7 @@ CardDialog.propTypes = {
   customAttributes: PropTypes.array.isRequired,
   uiActions: PropTypes.object.isRequired,
   customAttributeActions: PropTypes.object.isRequired,
+  hierarchyEnabled: PropTypes.bool,
 }
 
 function mapStateToProps(state) {
@@ -649,6 +670,7 @@ function mapStateToProps(state) {
     books: state.present.books,
     isSeries: selectors.isSeriesSelector(state.present),
     positionOffset: selectors.positionOffsetSelector(state.present),
+    hierarchyEnabled: selectors.beatHierarchyIsOn(state),
   }
 }
 


### PR DESCRIPTION
# Motivation
When the Act Hierarchy is turned off, we want the user's experience to be the same as it was before.

# Change
When this PR is merged, a special case will kick in for beat titles.
If hierarchy is enabled and we're in the series view, we'll use the word "Beat" for auto-titling.
If hierarchy is enabled and we're in a book view, we'll use the word "Chapter" for auto-titling.

# Notes
When we un-beta this feature, it'll be imperative to clean up all the extra wiring.
It really is a bit cumbersome to pass the extra flags around!