### PR TITLE
kan-321 remove 'get a license' button on dev mode

### DIFF
--- a/src/app/containers/Navigation.js
+++ b/src/app/containers/Navigation.js
@@ -20,7 +20,7 @@ class Navigation extends Component {
   }
 
   renderTrialLinks() {
-    if (!trialMode) return null
+    if (!trialMode || process.env.NODE_ENV == 'development') return null
 
     return (
       <Navbar.Form pullRight style={{ marginRight: '15px' }}>

--- a/src/app/containers/Navigation.js
+++ b/src/app/containers/Navigation.js
@@ -20,7 +20,7 @@ class Navigation extends Component {
   }
 
   renderTrialLinks() {
-    if (!trialMode || process.env.NODE_ENV == 'development') return null
+    if (!trialMode || isDev) return null
 
     return (
       <Navbar.Form pullRight style={{ marginRight: '15px' }}>


### PR DESCRIPTION
![Screenshot from 2021-04-01 23-47-15](https://user-images.githubusercontent.com/19387007/113320371-07557680-9345-11eb-8bb5-814a13a1ea3f.png)

Removed the **Get a License** nav button on dev mode