### PR TITLE
Fix bug where wrong argument was passed to selectors

### DIFF
--- a/src/app/components/outline/BeatView.js
+++ b/src/app/components/outline/BeatView.js
@@ -166,8 +166,8 @@ function mapStateToProps(state) {
     hierarchyLevels: sortedHierarchyLevels(state.present),
     lines: sortedLinesByBookSelector(state.present),
     positionOffset: positionOffsetSelector(state.present),
-    hierarchyEnabled: beatHierarchyIsOn(state),
-    isSeries: isSeriesSelector(state),
+    hierarchyEnabled: beatHierarchyIsOn(state.present),
+    isSeries: isSeriesSelector(state.present),
   }
 }
 

--- a/src/app/components/outline/miniMap.js
+++ b/src/app/components/outline/miniMap.js
@@ -155,8 +155,8 @@ function mapStateToProps(state) {
     lines: sortedLinesByBookSelector(state.present),
     ui: state.present.ui,
     positionOffset: positionOffsetSelector(state.present),
-    hierarchyEnabled: beatHierarchyIsOn(state),
-    isSeries: isSeriesSelector(state),
+    hierarchyEnabled: beatHierarchyIsOn(state.present),
+    isSeries: isSeriesSelector(state.present),
   }
 }
 

--- a/src/app/components/timeline/CardDialog.js
+++ b/src/app/components/timeline/CardDialog.js
@@ -670,7 +670,7 @@ function mapStateToProps(state) {
     books: state.present.books,
     isSeries: selectors.isSeriesSelector(state.present),
     positionOffset: selectors.positionOffsetSelector(state.present),
-    hierarchyEnabled: selectors.beatHierarchyIsOn(state),
+    hierarchyEnabled: selectors.beatHierarchyIsOn(state.present),
   }
 }
 


### PR DESCRIPTION
Fixes a fat finger mistake I made when I special-cased beat titles to revert to old names when we don't have the beat hierarchy turned on.