### PR TITLE
Add docs for plottr_components

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,53 @@ path of `/lib`.
     git subtree add --prefix lib/pltr pltr master --squash
 ```
 
+# The `plottr_components` Library
+
+The [component library repo](https://github.com/Plotinator/plottr_components) is the new home of our components! :)
+This branch adds `plottr_components` as a `git sub-tree` in the `/lib` folder.
+
+## Working With the Library
+
+You change the `plottr_components` library the same way you would work with `plottr_locales` or `pltr`.
+i.e. develop `plottr_electron` as though it doesn't contain any subtrees, and push the changes to Github using the subtree commands in the [Readme](https://github.com/cameronsutter/plottr_electron#readme).
+
+## Working Out-Of-Tree
+
+You can also work on the components out-of-tree (i.e. checked out to a folder other than `plottr_electron/lib`) as long as the other Plottr libraries are checked out as sibling folders of this library.
+i.e. you can checkout `pltr`, `plottr_locales` and `plottr_components` to an arbitrary folder on your computer and work with them like they're individual git repositories.
+
+## Storybook
+
+The component library comes with Storybook installed and configured.
+Storybook helps you develop components in isolation of the rest of the application to be more sure that the components work in isolation.
+The idea here is that if it works and looks good in Storybook, then it's the application's job to replicate how it looks and behaves in Storybook.
+
+### Starting the Watch-Compiler for Components
+
+You need to start a watcher process for the component library as well as the `plottr_electron` app if you're making changes to components.
+To start the component library watch compiler, run the following commands from the root of the repository:
+
+```bash
+  cd lib/plottr_components
+  npm run start
+```
+
+The compiler doesn't use webpack and doesn't minify anything.
+It simply runs the Sass compiler and babel directly.
+It's intended to be a light-weight process which reflects changes quickly, aids in debugging and doesn't place more burden on your system.
+
+### Starting Storybook
+
+While you make changes to components it's recommended that you start up Storybook to watch how the components look in isolation from `plottr_electron`.
+You can start the storybook by running the following commands from the root of the repository:
+
+```bash
+  cd lib/plottr_components
+  npm run storybook
+```
+
+The storybook will open in a new tab and changes that you make to components will reflect via Webpack's Hot Module Reloading (HMR) -- i.e. they'll reflect pretty quickly and without refreshing the page.
+
 # Debugging Tests
 
 To debug a test:


### PR DESCRIPTION
I added the notes of the embed plottr_components PR to the root README because I thought they might be useful after writing them.