### PR TITLE
Fix an import of `plottr_locales`

### DIFF
--- a/src/app/components/dialogs/BeatConfigModal.js
+++ b/src/app/components/dialogs/BeatConfigModal.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import { PropTypes } from 'prop-types'
 import { Glyphicon, ButtonToolbar, Button } from 'react-bootstrap'
 import DeleteConfirmModal from '../dialogs/DeleteConfirmModal'
-import i18n from 'format-message'
+import { t as i18n } from 'plottr_locales'
 
 import PlottrModal from 'components/PlottrModal'
 import HierarchyLevel from './HierarchyLevel'


### PR DESCRIPTION
We missed this one when we merged the hierarchy feature branch.