### PR TITLE
Set locale when we change it so that it reflects on the dashboard

### DIFF
--- a/src/common/components/LanguagePicker.js
+++ b/src/common/components/LanguagePicker.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import electron from 'electron'
-import { localeNames, getCurrentLocale } from 'plottr_locales'
+import { localeNames, getCurrentLocale, setupI18n } from 'plottr_locales'
 import SETTINGS from '../utils/settings'
 
 export default function LanguagePicker(props) {
   const onSelect = (event) => {
     SETTINGS.set('locale', event.target.value)
+    setupI18n(SETTINGS, { electron })
   }
 
   const renderedOptions = Object.entries(localeNames).map((entry) => {


### PR DESCRIPTION
We need to call out to `setupi18N` when we change language in the settings area for language changes to reflect on the dashboard immediately.
It's set up before this PR will mean that you need to open a new document to change the language.