### PR TITLE
added min-height to dashboard file icon text

### DIFF
--- a/src/app/components/dialogs/ActsConfigModal.js
+++ b/src/app/components/dialogs/ActsConfigModal.js
@@ -79,7 +79,9 @@ const ActsConfigModal = ({
   const RemoveLevelConfirmation = () =>
     stagedHierarchyLevels ? (
       <DeleteConfirmModal
-        customText={t('Are you sure?  (Removing levels may delete scene cards from all books across the project!)')}
+        customText={t(
+          'Are you sure?  (Removing levels may delete scene cards from all books across the project!)'
+        )}
         onDelete={() => {
           setHierarchyLevels(stagedHierarchyLevels)
           setStagedHierarchyLevels(null)

--- a/src/app/components/intros/Tour.js
+++ b/src/app/components/intros/Tour.js
@@ -106,7 +106,7 @@ class Tour extends Component {
         callback={this.handleJoyrideCallback}
         styles={{
           options: {
-            zIndex: 1001
+            zIndex: 1001,
           },
           buttonNext: {
             backgroundColor: '#ff9466',
@@ -115,9 +115,9 @@ class Tour extends Component {
           buttonBack: {
             color: '#ff9466',
           },
-          tooltipTitle:{
-            color:'black'
-          }
+          tooltipTitle: {
+            color: 'black',
+          },
         }}
       />
     )

--- a/src/app/components/timeline/BeatTitleCell.js
+++ b/src/app/components/timeline/BeatTitleCell.js
@@ -208,11 +208,11 @@ class BeatTitleCell extends PureComponent {
           <Button bsSize={isSmall ? 'small' : undefined} onClick={this.handleDelete}>
             <Glyphicon glyph="trash" />
           </Button>
-          {hierarchyLevel.level < 2 &&
+          {hierarchyLevel.level < 2 && (
             <Button bsSize={isSmall ? 'small' : undefined} onClick={this.handleToggleExpanded}>
               {beat.expanded ? <FaCompressAlt /> : <FaExpandAlt />}
             </Button>
-          }
+          )}
         </ButtonGroup>
       </div>
     )

--- a/src/css/dashboard/darkmode.scss
+++ b/src/css/dashboard/darkmode.scss
@@ -108,6 +108,7 @@ main.darkmode {
   .dashboard__new-files__item {
     color: $dark-text;
     background: $dark-gray-1;
+    row-gap: 20px;
     &.icon {
       svg {
         color: $dark-gray-5;

--- a/src/css/dashboard/files.scss
+++ b/src/css/dashboard/files.scss
@@ -59,6 +59,10 @@
     background-color: $blue-9;
     box-shadow: $blue-highlight-box-shadow;
   }
+
+  & div {
+    min-height: 60px;
+  }
 }
 
 .template-picker__dialog-wrapper {


### PR DESCRIPTION
ticket link: https://app.ora.pm/p/613886e300e4495da43eb09e27f99a61?v=0&t=k&c=c4826140c9f244b8b2e6daff41c24a4b
I have added a min-height for the text below the dashboard icons and it still show inconsistent icon button height when on 551px size, which i think the user wouldn't want to resize the app on 550px small since it is a desktop app. What do you guys think?
![dashboard-icon-text](https://user-images.githubusercontent.com/19387007/115098651-c3c55400-9f63-11eb-8cd0-2ba93620dfe0.png)

