### PR TITLE
Disable adding plot lines from templates

### DIFF
--- a/src/app/components/timeline/AddLineRow.js
+++ b/src/app/components/timeline/AddLineRow.js
@@ -233,7 +233,7 @@ class AddLineRow extends Component {
   }
 
   renderInsertButton() {
-    const { isSmall, isMedium, ui, actions } = this.props
+    const { hierarchyEnabled, isSmall, isMedium, ui, actions } = this.props
     if (isSmall) {
       return (
         <th className="row-header">
@@ -256,8 +256,12 @@ class AddLineRow extends Component {
         {this.state.hovering ? (
           <div className="line-list__append-line__double">
             <div
-              onClick={() => this.setState({ showTemplatePicker: true, hovering: false })}
-              className="template"
+              onClick={() => {
+                if (hierarchyEnabled) return
+                this.setState({ showTemplatePicker: true, hovering: false })
+              }}
+              title={hierarchyEnabled ? 'Templates are disabled when Act Structure is on' : null}
+              className={cx('template', { disabled: hierarchyEnabled })}
             >
               {i18n('Use Template')}
             </div>
@@ -324,6 +328,7 @@ class AddLineRow extends Component {
   }
 
   static propTypes = {
+    hierarchyEnabled: PropTypes.bool.isRequired,
     howManyCells: PropTypes.number,
     ui: PropTypes.object.isRequired,
     isSmall: PropTypes.bool,
@@ -341,6 +346,7 @@ class AddLineRow extends Component {
 
 function mapStateToProps(state) {
   return {
+    hierarchyEnabled: selectors.beatHierarchyIsOn(state.present),
     ui: state.present.ui,
     isSmall: selectors.isSmallSelector(state.present),
     isMedium: selectors.isMediumSelector(state.present),

--- a/src/css/line_block.css.scss
+++ b/src/css/line_block.css.scss
@@ -154,6 +154,11 @@ $medium_width: 80px;
       border-right: none;
       text-align: center;
     }
+    div.disabled {
+      cursor: $cursor-disabled;
+      color: $neutral-gray-5;
+      background-color: transparent;
+    }
     div.non-template {
       border-left: none;
     }
@@ -197,6 +202,11 @@ $medium_width: 80px;
     .line-list__append-line__double {
       div.template:not(:hover) {
         color: white;
+      }
+    }
+    .line-list__append-line__double {
+      div.disabled:not(:hover) {
+        color: $neutral-gray-5;
       }
     }
   }


### PR DESCRIPTION
# Disable Plot Line Templates
The Act Structure feature didn't completely address adding plot lines from templates.
We've decided to disable the feature until we figure out how to do it correctly.
See: https://plottrapp.slack.com/archives/C01RL8ZAQ1J/p1618838711165200