### PR TITLE
Remove save as template from CustomAttributes on the Places tab

### DIFF
--- a/src/app/components/places/PlaceListView.js
+++ b/src/app/components/places/PlaceListView.js
@@ -232,7 +232,7 @@ class PlaceListView extends Component {
     if (!this.state.dialogOpen) {
       return null
     }
-    return <CustomAttributeModal type="places" closeDialog={this.closeDialog} />
+    return <CustomAttributeModal hideSaveAsTemplate type="places" closeDialog={this.closeDialog} />
   }
 
   render() {


### PR DESCRIPTION
There's no way to add a place using a template, so we shouldn't be able to create them.