### PR TITLE
Bugfix/act structure textcolor

### DIFF
--- a/lib/plottr_components/src/components/dialogs/ActsConfigModal.js
+++ b/lib/plottr_components/src/components/dialogs/ActsConfigModal.js
@@ -4,7 +4,7 @@ import { Glyphicon, Button } from 'react-bootstrap'
 import { t } from 'plottr_locales'
 import UnconnectedPlottrModal from '../PlottrModal'
 import DeleteConfirmModal from './DeleteConfirmModal'
-import HierarchyLevel from './HierarchyLevel'
+import UnconnectedHierarchyLevel from './HierarchyLevel'
 
 const modalStyles = {
   overlay: {
@@ -25,6 +25,7 @@ const modalStyles = {
 
 const ActsConfigModalConnector = (connector) => {
   const PlottrModal = UnconnectedPlottrModal(connector)
+  const HierarchyLevel = UnconnectedHierarchyLevel(connector)
   const {
     pltr: {
       helpers: {

--- a/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
+++ b/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
@@ -3,9 +3,13 @@ import PropTypes from 'prop-types'
 import { DropdownButton, MenuItem, Button, Glyphicon } from 'react-bootstrap'
 import { t } from 'plottr_locales'
 import { IoIosReturnRight } from 'react-icons/io'
+import { helpers } from 'pltr/v2'
 
 import { ColorPicker, ColorPickerColor } from 'connected-components'
-import { getTextColor } from '../../../../pltr/v2/helpers/colors'
+
+const {
+  colors: { getTextColor },
+} = helpers
 
 const EditOrDisplay = ({
   id,
@@ -79,7 +83,6 @@ const EditOrDisplay = ({
   }
 
   const DisplaySwitch = () => {
-    console.log('display switch', isDarkMode)
     switch (type) {
       case 'toggle':
         return (
@@ -108,9 +111,8 @@ const EditOrDisplay = ({
       case 'color':
         return (
           <div className="acts-modal__levels-table-cell">
-            {console.log(getTextColor(isDarkMode))}
             <ColorPickerColor
-              color={value || getTextColor(isDarkMode)} // $gray-9
+              color={getTextColor(value, isDarkMode)}
               choose={() => {
                 setEditing(true)
               }}
@@ -163,10 +165,10 @@ EditOrDisplay.propTypes = {
   type: PropTypes.string.isRequired,
   setValue: PropTypes.func.isRequired,
   setEditing: PropTypes.func.isRequired,
+  isDarkMode: PropTypes.bool.isRequired,
   options: PropTypes.array,
   hideArrow: PropTypes.bool,
   addSpacer: PropTypes.bool,
-  isDarkMode: PropTypes.bool,
 }
 
 export default EditOrDisplay

--- a/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
+++ b/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
@@ -16,6 +16,7 @@ const EditOrDisplay = ({
   options,
   hideArrow,
   addSpacer,
+  isDarkMode,
 }) => {
   const [stagedValue, setStagedValue] = useState(value)
   useEffect(() => {
@@ -117,7 +118,7 @@ const EditOrDisplay = ({
               block
               title={t('No color')}
               bsStyle="warning"
-              onClick={() => setValue('none')}
+              onClick={() => setValue(`${isDarkMode ? 'none' : '#0B1117'}`)}
             >
               <Glyphicon glyph="ban-circle" />
             </Button>
@@ -162,6 +163,7 @@ EditOrDisplay.propTypes = {
   options: PropTypes.array,
   hideArrow: PropTypes.bool,
   addSpacer: PropTypes.bool,
+  isDarkMode: PropTypes.bool,
 }
 
 export default EditOrDisplay

--- a/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
+++ b/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
@@ -5,6 +5,7 @@ import { t } from 'plottr_locales'
 import { IoIosReturnRight } from 'react-icons/io'
 
 import { ColorPicker, ColorPickerColor } from 'connected-components'
+import { getTextColor } from '../../../../pltr/v2/helpers/colors'
 
 const EditOrDisplay = ({
   id,
@@ -78,6 +79,7 @@ const EditOrDisplay = ({
   }
 
   const DisplaySwitch = () => {
+    console.log('display switch', isDarkMode)
     switch (type) {
       case 'toggle':
         return (
@@ -106,8 +108,9 @@ const EditOrDisplay = ({
       case 'color':
         return (
           <div className="acts-modal__levels-table-cell">
+            {console.log(getTextColor(isDarkMode))}
             <ColorPickerColor
-              color={value || '#F1F5F8'} // $gray-9
+              color={value || getTextColor(isDarkMode)} // $gray-9
               choose={() => {
                 setEditing(true)
               }}
@@ -118,7 +121,7 @@ const EditOrDisplay = ({
               block
               title={t('No color')}
               bsStyle="warning"
-              onClick={() => setValue(`${isDarkMode ? 'none' : '#0B1117'}`)}
+              onClick={() => setValue('none')}
             >
               <Glyphicon glyph="ban-circle" />
             </Button>

--- a/lib/plottr_components/src/components/dialogs/HierarchyLevel.js
+++ b/lib/plottr_components/src/components/dialogs/HierarchyLevel.js
@@ -21,6 +21,7 @@ const HierarchyLevel = ({
   editHierarchyLevel,
   isHighest,
   isLowest,
+  ui,
 }) => {
   // XXXXXX - beats/hierarchy configuration modal
   const [editingName, setEditingName] = useState(false)
@@ -65,6 +66,7 @@ const HierarchyLevel = ({
         setEditing={setEditingTextColor}
         editing={editingTextColor}
         value={textColor}
+        isDarkMode={ui.darkMode}
       />
       <EditOrDisplay
         id={`hierarchy-level-auto-text-size-${level}`}
@@ -116,6 +118,12 @@ HierarchyLevel.propTypes = {
   editHierarchyLevel: PropTypes.func.isRequired,
   isHighest: PropTypes.bool.isRequired,
   isLowest: PropTypes.bool.isRequired,
+  ui: PropTypes.object,
 }
 
-export default connect(null, { editHierarchyLevel })(HierarchyLevel)
+export default connect(
+  (state) => ({
+    ui: state.present.ui,
+  }),
+  { editHierarchyLevel }
+)(HierarchyLevel)

--- a/lib/plottr_components/src/components/dialogs/HierarchyLevel.js
+++ b/lib/plottr_components/src/components/dialogs/HierarchyLevel.js
@@ -3,127 +3,140 @@ import { PropTypes } from 'prop-types'
 import { connect } from 'react-redux'
 
 import EditOrDisplay from './EditOrDisplay'
-import { actions, borderStyle as borderStyles } from 'pltr/v2'
+import { borderStyle as borderStyles } from 'pltr/v2'
 
-const {
-  hierarchyLevels: { editHierarchyLevel },
-} = actions
+const HierarchyLevelConnector = (connector) => {
+  const HierarchyLevel = ({
+    name,
+    level,
+    autoNumber,
+    textColor,
+    textSize,
+    borderColor,
+    borderStyle,
+    backgroundColor,
+    editHierarchyLevel,
+    isHighest,
+    isLowest,
+    ui,
+  }) => {
+    // XXXXXX - beats/hierarchy configuration modal
+    const [editingName, setEditingName] = useState(false)
+    const [editingAutoNumber, setEditingAutoNumber] = useState(false)
+    const [editingTextColor, setEditingTextColor] = useState(false)
+    const [editingTextSize, setEditingTextSize] = useState(false)
+    const [editingBorderColor, setEditingBorderColor] = useState(false)
+    const [editingBorderStyle, setEditingBorderStyle] = useState(false)
+    const [editingBackgroundColor, setEditingBackgroundColor] = useState(false)
 
-const HierarchyLevel = ({
-  name,
-  level,
-  autoNumber,
-  textColor,
-  textSize,
-  borderColor,
-  borderStyle,
-  backgroundColor,
-  editHierarchyLevel,
-  isHighest,
-  isLowest,
-  ui,
-}) => {
-  // XXXXXX - beats/hierarchy configuration modal
-  const [editingName, setEditingName] = useState(false)
-  const [editingAutoNumber, setEditingAutoNumber] = useState(false)
-  const [editingTextColor, setEditingTextColor] = useState(false)
-  const [editingTextSize, setEditingTextSize] = useState(false)
-  const [editingBorderColor, setEditingBorderColor] = useState(false)
-  const [editingBorderStyle, setEditingBorderStyle] = useState(false)
-  const [editingBackgroundColor, setEditingBackgroundColor] = useState(false)
+    const setValue = (name) => (newValue) => {
+      editHierarchyLevel({
+        level: level,
+        [name]: newValue,
+      })
+    }
 
-  const setValue = (name) => (newValue) => {
-    editHierarchyLevel({
-      level: level,
-      [name]: newValue,
-    })
+    return (
+      <div className="acts-modal__levels-table-row acts-tour-step4">
+        <EditOrDisplay
+          id={`hierarchy-level-name-config-${level}`}
+          type="text"
+          setValue={setValue('name')}
+          setEditing={setEditingName}
+          editing={editingName}
+          value={name}
+          hideArrow={isHighest}
+          addSpacer={isLowest}
+        />
+        <EditOrDisplay
+          id={`hierarchy-level-auto-number-config-${level}`}
+          type="toggle"
+          setValue={setValue('autoNumber')}
+          setEditing={setEditingAutoNumber}
+          editing={editingAutoNumber}
+          value={autoNumber}
+        />
+        <EditOrDisplay
+          id={`hierarchy-level-auto-text-color-${level}`}
+          type="color"
+          setValue={setValue('textColor')}
+          setEditing={setEditingTextColor}
+          editing={editingTextColor}
+          value={textColor}
+          isDarkMode={ui.darkMode}
+        />
+        <EditOrDisplay
+          id={`hierarchy-level-auto-text-size-${level}`}
+          type="number"
+          setValue={setValue('textSize')}
+          setEditing={setEditingTextSize}
+          editing={editingTextSize}
+          value={textSize}
+          hideArrow={true}
+        />
+        <EditOrDisplay
+          id={`hierarchy-level-auto-border-color-${level}`}
+          type="color"
+          setValue={setValue('borderColor')}
+          setEditing={setEditingBorderColor}
+          editing={editingBorderColor}
+          value={borderColor}
+        />
+        <EditOrDisplay
+          id={`hierarchy-level-auto-border-style-${level}`}
+          type="select"
+          options={borderStyles.ALL_STYLES}
+          setValue={setValue('borderStyle')}
+          setEditing={setEditingBorderStyle}
+          editing={editingBorderStyle}
+          value={borderStyle}
+        />
+        <EditOrDisplay
+          id={`hierarchy-level-auto-background-color-${level}`}
+          type="color"
+          setValue={setValue('backgroundColor')}
+          setEditing={setEditingBackgroundColor}
+          editing={editingBackgroundColor}
+          value={backgroundColor}
+        />
+      </div>
+    )
   }
 
-  return (
-    <div className="acts-modal__levels-table-row acts-tour-step4">
-      <EditOrDisplay
-        id={`hierarchy-level-name-config-${level}`}
-        type="text"
-        setValue={setValue('name')}
-        setEditing={setEditingName}
-        editing={editingName}
-        value={name}
-        hideArrow={isHighest}
-        addSpacer={isLowest}
-      />
-      <EditOrDisplay
-        id={`hierarchy-level-auto-number-config-${level}`}
-        type="toggle"
-        setValue={setValue('autoNumber')}
-        setEditing={setEditingAutoNumber}
-        editing={editingAutoNumber}
-        value={autoNumber}
-      />
-      <EditOrDisplay
-        id={`hierarchy-level-auto-text-color-${level}`}
-        type="color"
-        setValue={setValue('textColor')}
-        setEditing={setEditingTextColor}
-        editing={editingTextColor}
-        value={textColor}
-        isDarkMode={ui.darkMode}
-      />
-      <EditOrDisplay
-        id={`hierarchy-level-auto-text-size-${level}`}
-        type="number"
-        setValue={setValue('textSize')}
-        setEditing={setEditingTextSize}
-        editing={editingTextSize}
-        value={textSize}
-        hideArrow={true}
-      />
-      <EditOrDisplay
-        id={`hierarchy-level-auto-border-color-${level}`}
-        type="color"
-        setValue={setValue('borderColor')}
-        setEditing={setEditingBorderColor}
-        editing={editingBorderColor}
-        value={borderColor}
-      />
-      <EditOrDisplay
-        id={`hierarchy-level-auto-border-style-${level}`}
-        type="select"
-        options={borderStyles.ALL_STYLES}
-        setValue={setValue('borderStyle')}
-        setEditing={setEditingBorderStyle}
-        editing={editingBorderStyle}
-        value={borderStyle}
-      />
-      <EditOrDisplay
-        id={`hierarchy-level-auto-background-color-${level}`}
-        type="color"
-        setValue={setValue('backgroundColor')}
-        setEditing={setEditingBackgroundColor}
-        editing={editingBackgroundColor}
-        value={backgroundColor}
-      />
-    </div>
-  )
+  HierarchyLevel.propTypes = {
+    name: PropTypes.string.isRequired,
+    level: PropTypes.number.isRequired,
+    autoNumber: PropTypes.bool.isRequired,
+    textColor: PropTypes.string.isRequired,
+    textSize: PropTypes.number.isRequired,
+    borderColor: PropTypes.string.isRequired,
+    borderStyle: PropTypes.oneOf(borderStyles.ALL_STYLES),
+    backgroundColor: PropTypes.string.isRequired,
+    editHierarchyLevel: PropTypes.func.isRequired,
+    isHighest: PropTypes.bool.isRequired,
+    isLowest: PropTypes.bool.isRequired,
+    ui: PropTypes.object,
+  }
+
+  const { redux } = connector
+
+  if (redux) {
+    const {
+      pltr: { actions },
+    } = connector
+    const { connect } = redux
+    const {
+      hierarchyLevels: { editHierarchyLevel },
+    } = actions
+
+    return connect(
+      (state) => ({
+        ui: state.present.ui,
+      }),
+      { editHierarchyLevel }
+    )(HierarchyLevel)
+  }
+  throw new Error('Could not connect HierarchyLevel')
 }
 
-HierarchyLevel.propTypes = {
-  name: PropTypes.string.isRequired,
-  level: PropTypes.number.isRequired,
-  autoNumber: PropTypes.bool.isRequired,
-  textColor: PropTypes.string.isRequired,
-  textSize: PropTypes.number.isRequired,
-  borderColor: PropTypes.string.isRequired,
-  borderStyle: PropTypes.oneOf(borderStyles.ALL_STYLES),
-  backgroundColor: PropTypes.string.isRequired,
-  editHierarchyLevel: PropTypes.func.isRequired,
-  isHighest: PropTypes.bool.isRequired,
-  isLowest: PropTypes.bool.isRequired,
-  ui: PropTypes.object,
-}
-
-export default connect(
-  (state) => ({
-    ui: state.present.ui,
-  }),
-  { editHierarchyLevel }
-)(HierarchyLevel)
+export default HierarchyLevelConnector

--- a/lib/plottr_components/src/components/dialogs/HierarchyLevel.js
+++ b/lib/plottr_components/src/components/dialogs/HierarchyLevel.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { PropTypes } from 'prop-types'
-import { connect } from 'react-redux'
 
 import EditOrDisplay from './EditOrDisplay'
 import { borderStyle as borderStyles } from 'pltr/v2'
@@ -20,7 +19,6 @@ const HierarchyLevelConnector = (connector) => {
     isLowest,
     ui,
   }) => {
-    // XXXXXX - beats/hierarchy configuration modal
     const [editingName, setEditingName] = useState(false)
     const [editingAutoNumber, setEditingAutoNumber] = useState(false)
     const [editingTextColor, setEditingTextColor] = useState(false)
@@ -47,6 +45,7 @@ const HierarchyLevelConnector = (connector) => {
           value={name}
           hideArrow={isHighest}
           addSpacer={isLowest}
+          isDarkMode={ui.darkMode}
         />
         <EditOrDisplay
           id={`hierarchy-level-auto-number-config-${level}`}
@@ -55,6 +54,7 @@ const HierarchyLevelConnector = (connector) => {
           setEditing={setEditingAutoNumber}
           editing={editingAutoNumber}
           value={autoNumber}
+          isDarkMode={ui.darkMode}
         />
         <EditOrDisplay
           id={`hierarchy-level-auto-text-color-${level}`}
@@ -73,6 +73,7 @@ const HierarchyLevelConnector = (connector) => {
           editing={editingTextSize}
           value={textSize}
           hideArrow={true}
+          isDarkMode={ui.darkMode}
         />
         <EditOrDisplay
           id={`hierarchy-level-auto-border-color-${level}`}
@@ -81,6 +82,7 @@ const HierarchyLevelConnector = (connector) => {
           setEditing={setEditingBorderColor}
           editing={editingBorderColor}
           value={borderColor}
+          isDarkMode={ui.darkMode}
         />
         <EditOrDisplay
           id={`hierarchy-level-auto-border-style-${level}`}
@@ -90,6 +92,7 @@ const HierarchyLevelConnector = (connector) => {
           setEditing={setEditingBorderStyle}
           editing={editingBorderStyle}
           value={borderStyle}
+          isDarkMode={ui.darkMode}
         />
         <EditOrDisplay
           id={`hierarchy-level-auto-background-color-${level}`}
@@ -98,6 +101,7 @@ const HierarchyLevelConnector = (connector) => {
           setEditing={setEditingBackgroundColor}
           editing={editingBackgroundColor}
           value={backgroundColor}
+          isDarkMode={ui.darkMode}
         />
       </div>
     )

--- a/lib/pltr/v2/helpers/colors.js
+++ b/lib/pltr/v2/helpers/colors.js
@@ -10,6 +10,8 @@ export const getContrastYIQ = (color) => {
   return [brightness >= 180, brightness]
 }
 
-export const getTextColor = (isDarkMode) => {
+export const getTextColor = (colour, isDarkMode) => {
+  if (colour !== 'none') return colour
+
   return isDarkMode ? defaultDarkModeText : defaultLightModeText
 }

--- a/lib/pltr/v2/helpers/colors.js
+++ b/lib/pltr/v2/helpers/colors.js
@@ -1,8 +1,15 @@
 import tinycolor from 'tinycolor2'
 
+const defaultLightModeText = '#0b1117'
+const defaultDarkModeText = '#eee'
+
 // returns [useBlack, value]
 export const getContrastYIQ = (color) => {
   const brightness = tinycolor(color).getBrightness()
   // >= 125 is the recommended functionality
   return [brightness >= 180, brightness]
+}
+
+export const getTextColor = (isDarkMode) => {
+  return isDarkMode ? defaultDarkModeText : defaultLightModeText
 }

--- a/lib/pltr/v2/helpers/hierarchy.js
+++ b/lib/pltr/v2/helpers/hierarchy.js
@@ -2,6 +2,7 @@ import { nextColor } from '../../v1/store/lineColors'
 import { DASHED, DOTTED, nextBorderStyle, NONE, SOLID } from '../store/borderStyle'
 import { hierarchyLevel } from '../store/initialState'
 import { t } from 'plottr_locales'
+import { getTextColor } from './colors'
 
 export const borderStyleToCss = (borderStyle) => {
   switch (borderStyle) {
@@ -31,7 +32,7 @@ export const hierarchyToStyles = (
   isDarkMode
 ) => ({
   ...{
-    color: nullIfNone(textColor === '#0B1117' && isDarkMode ? '#eee' : textColor),
+    color: nullIfNone(textColor || getTextColor(isDarkMode)),
     lineHeight: `${textSize}px`,
     backgroundColor: nullIfNone(backgroundColor),
   },

--- a/lib/pltr/v2/helpers/hierarchy.js
+++ b/lib/pltr/v2/helpers/hierarchy.js
@@ -27,10 +27,11 @@ const noneIsTransparent = (borderStyle, borderColor) => {
 export const hierarchyToStyles = (
   { level, textColor, textSize, borderColor, borderStyle, backgroundColor },
   timelineSize,
-  hovering
+  hovering,
+  isDarkMode
 ) => ({
   ...{
-    color: nullIfNone(textColor),
+    color: nullIfNone(textColor === '#0B1117' && isDarkMode ? '#eee' : textColor),
     lineHeight: `${textSize}px`,
     backgroundColor: nullIfNone(backgroundColor),
   },

--- a/lib/pltr/v2/store/lineColors.js
+++ b/lib/pltr/v2/store/lineColors.js
@@ -13,7 +13,7 @@ export function nextColor(length) {
     case 4:
       return '#ffc72c' // yellow
     default:
-      return '#0B1117' // black
+      return '#0b1117' // black
   }
 }
 

--- a/lib/pltr/v2/store/lineColors.js
+++ b/lib/pltr/v2/store/lineColors.js
@@ -13,7 +13,7 @@ export function nextColor(length) {
     case 4:
       return '#ffc72c' // yellow
     default:
-      return '#0b1117' // black
+      return '#0B1117' // black
   }
 }
 

--- a/src/app/components/timeline/BeatTitleCell.js
+++ b/src/app/components/timeline/BeatTitleCell.js
@@ -380,7 +380,8 @@ class BeatTitleCell extends PureComponent {
               style={hierarchyToStyles(
                 this.props.hierarchyLevel,
                 ui.timeline.size,
-                this.state.hovering || this.state.inDropZone
+                this.state.hovering || this.state.inDropZone,
+                ui.darkMode
               )}
               className={innerKlass}
               onClick={this.startEditing}


### PR DESCRIPTION
Gavin gray's bugfix requests
- In the Act Structure config modal, in light mode, when you remove the text color from any level, it makes the color “none”,
- Scene headings should appear as #EEE by default when you start a new project in dark mode
- In the Act Structure popup, if you click the no-color button for text color in dark mode, it should revert to #EEE