### PR TITLE
fix double entry and saving empty tags

### DIFF
--- a/lib/plottr_components/src/components/tag/TagView.js
+++ b/lib/plottr_components/src/components/tag/TagView.js
@@ -82,6 +82,7 @@ const TagViewConnector = (connector) => {
     }
 
     saveEdit = () => {
+      if (this.titleInputRef.value === '') return this.handleCancel()
       let { title, id, color } = this.props.tag
       var newTitle = this.titleInputRef.value || title
       if (this.props.new) {
@@ -133,7 +134,7 @@ const TagViewConnector = (connector) => {
     renderEditing() {
       const { tag } = this.props
       return (
-        <div onKeyDown={this.handleEsc}>
+        <div>
           <FormGroup>
             <ControlLabel>{i18n('Tag Name')}</ControlLabel>
             <FormControl


### PR DESCRIPTION
1. fix double entry tags
2. cancel saving empty tags names
Video fix evidence will be useless since the bugs exists on keyboard events