### PR TITLE
Don't put the content of block quotes into paragraphs

### DIFF
--- a/src/common/slate_serializers/to_word.js
+++ b/src/common/slate_serializers/to_word.js
@@ -103,6 +103,7 @@ const serialize = (nodes, doc) => {
         return new Paragraph({ children: [image] })
       }
       case 'block-quote':
+        return children
       case 'paragraph':
       default:
         if (Array.isArray(children)) {


### PR DESCRIPTION
# Fix Block Quotes in Word Export
The problem appears to be that the serializer wrapped the children of block quotes in a paragraph.
But block quotes are wrappers for collections of other elements.
So instead of wrapping the contents of a blockquote, we ought to return them, indented.

# Actually Representing Block Quotes
I had a quick stab at supporting block quotes, but I think that it'll take longer to get it working and we need the fix for the main problem soon.

Here's what I tried so far:

```diff
diff --git a/src/common/slate_serializers/to_word.js b/src/common/slate_serializers/to_word.js
index 9df05fe9..88963d63 100644
--- a/src/common/slate_serializers/to_word.js
+++ b/src/common/slate_serializers/to_word.js
@@ -40,24 +40,41 @@ const concrete = numbering.createConcreteNumbering(abstractNum)
 
 END NONE of this works */
 
-const serialize = (nodes, doc) => {
+const newIndentation = (node, currentIndentation) => {
+  if (node.type === 'block-quote') {
+    return currentIndentation + 1
+  }
+  return currentIndentation
+}
+
+const serialize = (nodes, doc, indentation = 0) => {
   if (!nodes || !nodes.flatMap) return []
   if (typeof nodes === 'string') return [new Paragraph({ children: [leaf({ text: nodes })] })]
 
   return nodes.flatMap((n) => {
     if (!n.children) return leaf(n)
 
-    const children = serialize(n.children, doc)
+    const newIndentationLevel = newIndentation(n, indentation)
+    const children = serialize(n.children, doc, newIndentationLevel)
+    const paragraphProps = indentation > 0 ? { indent: { left: 100 * indentation } } : {}
 
     switch (n.type) {
       case 'bulleted-list':
         return children.map((li) => {
           if (li instanceof TextRun) {
-            return new Paragraph({ children: [li], bullet: { level: 0 } })
+            return new Paragraph({
+              children: [li],
+              bullet: { level: 0 },
+              ...paragraphProps,
+            })
           } else {
             // this isn't allowed in the UI anymore (2021.1.12) but it may still exist in the wild
             if (li instanceof Paragraph)
-              return new Paragraph({ children: [li.root[1]], bullet: { level: 0 } })
+              return new Paragraph({
+                children: [li.root[1]],
+                bullet: { level: 0 },
+                ...paragraphProps,
+              })
           }
         })
       // Headings can sometimes have 1+ paragraph children, which the docx exporter does not allow
@@ -72,6 +89,7 @@ const serialize = (nodes, doc) => {
             return new Paragraph({
               children: [leaf(child)],
               heading: headingLevel,
+              ...paragraphProps,
             })
           }
 
@@ -79,6 +97,7 @@ const serialize = (nodes, doc) => {
             return new Paragraph({
               children: child.children.map(leaf),
               heading: headingLevel,
+              ...paragraphProps,
             })
           }
         })
@@ -87,27 +106,32 @@ const serialize = (nodes, doc) => {
         return children[0] // always an array with 1 TextRun
       case 'numbered-list':
         // make it a bullet list for now
-        return children.map((li) => new Paragraph({ children: [li], bullet: { level: 0 } }))
+        return children.map(
+          (li) => new Paragraph({ children: [li], bullet: { level: 0 }, ...paragraphProps })
+        )
       // this isn't working for now
       // return children.map(li => new Paragraph({children: [li.root[1]], numbering: { reference: concrete, level: 0 }}))
       case 'link':
         return doc.createHyperlink(n.url, n.url)
       case 'image-link':
-        return new Paragraph({ children: [doc.createHyperlink(n.url, n.url), ...children] })
+        return new Paragraph({
+          children: [doc.createHyperlink(n.url, n.url), ...children],
+          ...paragraphProps,
+        })
       case 'image-data': {
         const imgData = n.data
         const image = Media.addImage(
           doc,
           Buffer.from(imgData.replace('data:image/jpeg;base64,', ''), 'base64')
         )
-        return new Paragraph({ children: [image] })
+        return new Paragraph({ children: [image], ...paragraphProps })
       }
       case 'block-quote':
         return children
       case 'paragraph':
       default:
         if (Array.isArray(children)) {
-          return new Paragraph({ children: children })
+          return new Paragraph({ children: children, ...paragraphProps })
         }
     }
   })
```