### PR TITLE
Make Acts Tour More Robust

### DIFF
--- a/lib/plottr_components/src/components/dialogs/ActsConfigModal.js
+++ b/lib/plottr_components/src/components/dialogs/ActsConfigModal.js
@@ -32,6 +32,7 @@ const ActsConfigModalConnector = (connector) => {
       helpers: {
         hierarchyLevels: { newHierarchyLevel },
       },
+      tourConstants: { ACTS_TOUR },
     },
   } = connector
 
@@ -52,6 +53,10 @@ const ActsConfigModalConnector = (connector) => {
         levelsInputRef.current.setSelectionRange(0, levelsInputRef.current.value.length)
       }
     }
+
+    useEffect(() => {
+      tourNext(ACTS_TOUR, 0)
+    }, [])
 
     useEffect(() => {
       if (levelsInputRef.current && levelsInputRef.current === document.activeElement) {
@@ -93,15 +98,20 @@ const ActsConfigModalConnector = (connector) => {
         />
       ) : null
 
+    const advanceAndClose = (event) => {
+      tourNext(ACTS_TOUR, 4, true, true)
+      closeDialog(event)
+    }
+
     return (
       <>
         <RemoveLevelConfirmation />
-        <PlottrModal isOpen={true} onRequestClose={closeDialog} style={modalStyles}>
+        <PlottrModal isOpen={true} onRequestClose={advanceAndClose} style={modalStyles}>
           <div className="acts-modal__wrapper">
             <div className="acts-modal__header">
               <div>
                 <h3>{t('Act Structure')}</h3>
-                <Button onClick={closeDialog} className="acts-tour-step5">
+                <Button onClick={advanceAndClose} className="acts-tour-step5">
                   {t('Close')}
                 </Button>
               </div>
@@ -208,7 +218,6 @@ const ActsConfigModalConnector = (connector) => {
       (state) => ({
         levelsOfHierarchy: hierarchyLevelCount(state.present),
         hierarchyLevels: sortedHierarchyLevels(state.present),
-        tourState: selectors.tourSelector(state.present),
       }),
       { setHierarchyLevels, tourNext }
     )(ActsConfigModal)

--- a/lib/plottr_components/src/components/timeline/BeatInsertCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatInsertCell.js
@@ -14,6 +14,12 @@ const {
 } = helpers
 
 const BeatInsertCellConnector = (connector) => {
+  const {
+    pltr: {
+      tourConstants: { ACTS_TOUR },
+    },
+  } = connector
+
   class BeatInsertCell extends PureComponent {
     constructor(props) {
       super(props)
@@ -24,43 +30,15 @@ const BeatInsertCellConnector = (connector) => {
     }
 
     insert = () => {
-      const { beatToLeft, handleInsert, isLast } = this.props
+      const { beatToLeft, handleInsert } = this.props
       handleInsert(beatToLeft && beatToLeft.id)
-      if (this.props.hierarchyLevels.length > 1 && !isLast) {
-        let SCENE_CELL_WIDTH = this.props.isMedium ? 85 : 194 + 17
-        let SCENE_CELL_HEIGHT = this.props.isMedium ? 85 : 94 + 17
-
-        if (this.props.tour.run === true) this.props.tourActions.tourNext('next')
-
-        let children =
-          this.props.beats.index[beatToLeft.id].expanded && this.props.beats.children[beatToLeft.id]
-        let numChildren = children.length
-
-        let expandedChildren = 0
-        numChildren > 0 &&
-          children.forEach((child) => {
-            if (
-              this.props.beats.children[child].length > 0 &&
-              this.props.beats.index[child].expanded
-            ) {
-              expandedChildren += this.props.beats.children[child].length
-            }
-          })
-        //scroll based on how many children and grandChildren cards there are between clicked card and newly added card
-        const target =
-          this.props.orientation === 'vertical'
-            ? this.props.ui.timelineScrollPosition.y +
-              (numChildren + expandedChildren) * SCENE_CELL_HEIGHT
-            : this.props.ui.timelineScrollPosition.x +
-              (numChildren + expandedChildren) * SCENE_CELL_WIDTH
-
-        if (!this.props.tour.showTour) this.props.scrollTo(target)
-      }
+      this.props.tourActions.tourNext(ACTS_TOUR, 5)
     }
 
     insertChild = () => {
       const { beatToLeft, handleInsertChild, bookId } = this.props
       handleInsertChild(beatToLeft && beatToLeft.id, bookId)
+      this.props.tourActions.tourNext(ACTS_TOUR, 7)
     }
 
     lastTitleText = () => {
@@ -201,7 +179,7 @@ const BeatInsertCellConnector = (connector) => {
     }
 
     renderToggleCollapse() {
-      const { handleInsertChild, toggleExpanded, expanded, tour, isFirst } = this.props
+      const { handleInsertChild, toggleExpanded, expanded, isFirst } = this.props
 
       return !handleInsertChild && toggleExpanded ? (
         <div
@@ -214,7 +192,7 @@ const BeatInsertCellConnector = (connector) => {
           <div className={this.wrapperClassSubIcon()}>
             <div
               onClick={() =>
-                !isFirst && expanded === true && tour.run && this.props.tourActions.tourNext('next')
+                !isFirst && expanded === true && this.props.tourActions.tourNext(ACTS_TOUR, 7)
               }
             >
               {expanded ? <FaCompressAlt /> : <FaExpandAlt />}
@@ -354,7 +332,6 @@ const BeatInsertCellConnector = (connector) => {
       isInBeatList: PropTypes.bool.isRequired,
       actions: PropTypes.object.isRequired,
       hovering: PropTypes.number,
-      tour: PropTypes.object.isRequired,
       tourActions: PropTypes.object.isRequired,
       beatToLeft: PropTypes.object,
       lineId: PropTypes.number,
@@ -402,7 +379,6 @@ const BeatInsertCellConnector = (connector) => {
             beatToLeftId
           ),
           atMaximumDepth: selectors.atMaximumHierarchyDepthSelector(state.present, beatToLeftId),
-          tour: selectors.tourSelector(state.present),
         }
       },
       (dispatch) => {

--- a/lib/plottr_components/src/components/timeline/BeatTitleCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatTitleCell.js
@@ -25,6 +25,12 @@ const {
 } = helpers
 
 const BeatTitleCellConnector = (connector) => {
+  const {
+    pltr: {
+      tourConstants: { ACTS_TOUR },
+    },
+  } = connector
+
   class BeatTitleCell extends PureComponent {
     constructor(props) {
       super(props)
@@ -57,13 +63,12 @@ const BeatTitleCellConnector = (connector) => {
 
     handleAddBeat = (e) => {
       this.props.actions.insertBeat(this.props.ui.currentTimeline, this.props.beat.id)
-      if (this.props.tour.run === true) this.props.tourActions.tourNext('next')
+      this.props.tourActions.tourNext(ACTS_TOUR, 6)
 
       let SCENE_CELL_WIDTH = this.props.isMedium ? 90 : 175 + 17
       let SCENE_CELL_HEIGHT = this.props.isMedium ? 85 : 94 + 17
 
       this.props.actions.expandBeat(this.props.beat.id, this.props.ui.currentTimeline)
-      // if (this.props.tour.run === true) this.props.tourActions.tourNext('next')
 
       let children = this.props.beats.children[this.props.beat.id]
       let numChildren = children.length
@@ -82,7 +87,7 @@ const BeatTitleCellConnector = (connector) => {
           : this.props.ui.timelineScrollPosition.x +
             (numChildren + expandedChildren) * SCENE_CELL_WIDTH
 
-      if (!this.props.tour.showTour) this.props.scrollTo(target)
+      this.props.scrollTo(target)
     }
 
     handleAddChild = (e) => {
@@ -91,7 +96,7 @@ const BeatTitleCellConnector = (connector) => {
 
       this.props.actions.expandBeat(this.props.beat.id, this.props.ui.currentTimeline)
       this.props.actions.addBeat(this.props.ui.currentTimeline, this.props.beat.id)
-      if (this.props.tour.run === true) this.props.tourActions.tourNext('next')
+      this.props.tourActions.tourNext(ACTS_TOUR, 7)
 
       let children = this.props.beats.children[this.props.beat.id]
       let numChildren = children.length
@@ -118,10 +123,9 @@ const BeatTitleCellConnector = (connector) => {
         actions: { collapseBeat, expandBeat },
         beat: { id, expanded },
         ui: { currentTimeline },
-        tour,
       } = this.props
 
-      if (expanded === true && tour.run === true) this.props.tourActions.tourNext('next')
+      this.props.tourActions.tourNext(ACTS_TOUR, 6)
 
       if (expanded) collapseBeat(id, currentTimeline)
       else expandBeat(id, currentTimeline)
@@ -257,7 +261,7 @@ const BeatTitleCellConnector = (connector) => {
     }
 
     renderHorizontalHoverOptions(style) {
-      const { ui, isMedium, isSmall, beat, hierarchyLevel, hierarchyLevels, tour } = this.props
+      const { ui, isMedium, isSmall, beat, hierarchyLevel, hierarchyLevels } = this.props
       const klasses = orientedClassName('beat-list__item__hover-options', ui.orientation)
       const showExpandCollapse = hierarchyLevels.length - hierarchyLevel.level > 1
       return (
@@ -274,7 +278,7 @@ const BeatTitleCellConnector = (connector) => {
             {showExpandCollapse ? (
               <Button
                 bsSize={isSmall ? 'small' : undefined}
-                className={tour.run ? 'acts-tour-step7' : ''}
+                className={'acts-tour-step7'}
                 onClick={this.handleToggleExpanded}
               >
                 {beat.expanded ? <FaCompressAlt /> : <FaExpandAlt />}
@@ -286,16 +290,7 @@ const BeatTitleCellConnector = (connector) => {
     }
 
     renderLowerHoverOptions(style) {
-      const {
-        ui,
-        isMedium,
-        isSmall,
-        isFirst,
-        beatId,
-        hierarchyLevel,
-        hierarchyLevels,
-        tour,
-      } = this.props
+      const { ui, isMedium, isSmall, isFirst, beatId, hierarchyLevel, hierarchyLevels } = this.props
       const klasses = orientedClassName('medium-lower-hover-options', ui.orientation)
 
       style = { visibility: 'hidden' }
@@ -305,7 +300,7 @@ const BeatTitleCellConnector = (connector) => {
 
       let button1 = (
         <Button
-          className={!isFirst && tour.run ? 'acts-tour-step6' : null}
+          className={!isFirst && 'acts-tour-step6'}
           bsSize={isSmall ? 'small' : undefined}
           block
           onClick={this.handleAddBeat}
@@ -348,7 +343,7 @@ const BeatTitleCellConnector = (connector) => {
     }
 
     renderVerticalHoverOptions(style) {
-      const { ui, isSmall, isMedium, beat, hierarchyLevel, hierarchyLevels, tour } = this.props
+      const { ui, isSmall, isMedium, beat, hierarchyLevel, hierarchyLevels } = this.props
       const klasses = orientedClassName('beat-list__item__hover-options', ui.orientation)
       const showExpandCollapse = hierarchyLevels.length - hierarchyLevel.level > 1
       return (
@@ -375,7 +370,7 @@ const BeatTitleCellConnector = (connector) => {
           {showExpandCollapse && (
             <Button
               bsSize={isSmall ? 'small' : undefined}
-              className={tour.run ? 'acts-tour-step7' : ''}
+              className={'acts-tour-step7'}
               onClick={this.handleToggleExpanded}
             >
               {beat.expanded ? <FaCompressAlt /> : <FaExpandAlt />}
@@ -580,7 +575,6 @@ const BeatTitleCellConnector = (connector) => {
     isMedium: PropTypes.bool.isRequired,
     hierarchyEnabled: PropTypes.bool.isRequired,
     isSeries: PropTypes.bool.isRequired,
-    tour: PropTypes.object.isRequired,
     tourActions: PropTypes.object.isRequired,
     onMouseLeave: PropTypes.func.isRequired,
     onMouseEnter: PropTypes.func.isRequired,
@@ -614,7 +608,6 @@ const BeatTitleCellConnector = (connector) => {
           isMedium: selectors.isMediumSelector(state.present),
           hierarchyEnabled: selectors.beatHierarchyIsOn(state.present),
           isSeries: selectors.isSeriesSelector(state.present),
-          tour: selectors.tourSelector(state.present),
         }
       }
     }

--- a/lib/plottr_components/src/components/timeline/TimelineWrapper.js
+++ b/lib/plottr_components/src/components/timeline/TimelineWrapper.js
@@ -96,14 +96,6 @@ const TimelineWrapperConnector = (connector) => {
           10
         )
       }
-      // if () {
-      //   this.setState({mounted: false})
-      //   setTimeout(() => this.setState({mounted: true}), 100)
-      // }
-      // if () {
-      //   this.setState({mounted: false})
-      //   setTimeout(() => this.setState({mounted: true}), 100)
-      // }
     }
 
     componentWillUnmount() {
@@ -121,16 +113,12 @@ const TimelineWrapperConnector = (connector) => {
       this.setState({
         beatConfigIsOpen: false,
       })
-      if (this.props.tour.run && this.props.tour.stepIndex === 4)
-        this.props.tourActions.tourNext('next')
     }
 
     openBeatConfig = () => {
       this.setState({
         beatConfigIsOpen: true,
       })
-      if (this.props.tour.run && this.props.tour.stepIndex === 0)
-        this.props.tourActions.tourNext('next')
     }
 
     // ///////////////
@@ -444,7 +432,6 @@ const TimelineWrapperConnector = (connector) => {
     filterIsEmpty: PropTypes.bool.isRequired,
     actions: PropTypes.object.isRequired,
     tourActions: PropTypes.object.isRequired,
-    tour: PropTypes.object.isRequired,
   }
 
   const {
@@ -464,7 +451,6 @@ const TimelineWrapperConnector = (connector) => {
           isMedium: selectors.isMediumSelector(state.present),
           isLarge: selectors.isLargeSelector(state.present),
           featureFlags: selectors.featureFlags(state.present),
-          tour: selectors.tourSelector(state.present),
         }
       },
       (dispatch) => {

--- a/lib/pltr/v2/actions/tours.js
+++ b/lib/pltr/v2/actions/tours.js
@@ -1,21 +1,52 @@
-import { SET_TOUR_FEATURE, TOUR_NEXT, TOUR_RESTART } from '../constants/ActionTypes'
+import {
+  SET_TOUR_FEATURE,
+  TOUR_NEXT,
+  TOUR_RESTART,
+  TOUR_PREVIOUS,
+  RESET_ADVANCE_SOURCE,
+  SET_STEP,
+} from '../constants/ActionTypes'
 
-export function setTourFeature(payload) {
+export function setTourFeature(feature) {
   return {
     type: SET_TOUR_FEATURE,
-    payload,
+    feature,
   }
 }
 
-export function tourNext(payload) {
+export function tourNext(feature, source, appInteractionAdvanced = true, resetIfMismatch) {
   return {
     type: TOUR_NEXT,
-    payload,
+    feature,
+    source,
+    appInteractionAdvanced,
+    resetIfMismatch,
   }
+}
+
+export function tourPrevious(feature, source, appInteractionAdvanced = true, resetIfMismatch) {
+  return {
+    type: TOUR_PREVIOUS,
+    feature,
+    source,
+    appInteractionAdvanced,
+    resetIfMismatch,
+  }
+}
+
+export function resetAdvanceSource() {
+  return { type: RESET_ADVANCE_SOURCE }
 }
 
 export function tourRestart() {
   return {
     type: TOUR_RESTART,
+  }
+}
+
+export function setStep(overridenStepIndex) {
+  return {
+    type: SET_STEP,
+    overridenStepIndex,
   }
 }

--- a/lib/pltr/v2/constants/ActionTypes.js
+++ b/lib/pltr/v2/constants/ActionTypes.js
@@ -174,4 +174,7 @@ export const UNSET_FEATURE_FLAG = 'UNSET_FEATURE_FLAG'
 // tour actions
 export const SET_TOUR_FEATURE = 'SET_TOUR_FEATURE'
 export const TOUR_NEXT = 'TOUR_NEXT'
+export const TOUR_PREVIOUS = 'TOUR_PREVIOUS'
 export const TOUR_RESTART = 'TOUR_RESTART'
+export const RESET_ADVANCE_SOURCE = 'RESET_ADVANCE_SOURCE'
+export const SET_STEP = 'SET_STEP'

--- a/lib/pltr/v2/constants/tour.js
+++ b/lib/pltr/v2/constants/tour.js
@@ -1,0 +1,1 @@
+export const ACTS_TOUR = 'ACTS_TOUR'

--- a/lib/pltr/v2/index.js
+++ b/lib/pltr/v2/index.js
@@ -19,6 +19,7 @@ import * as tourActions from './actions/tours'
 import * as ActionTypes from './constants/ActionTypes'
 import * as colors from './constants/CSScolors'
 import * as featureFlags from './constants/featureFlags'
+import * as tourConstants from './constants/tour'
 
 import * as lineHelpers from './helpers/lines'
 import * as cardHelpers from './helpers/cards'
@@ -154,6 +155,7 @@ export {
   helpers,
   colors,
   featureFlags,
+  tourConstants,
   migrateIfNeeded,
   rootReducer,
   mainReducer,

--- a/lib/pltr/v2/reducers/tours.js
+++ b/lib/pltr/v2/reducers/tours.js
@@ -1,65 +1,142 @@
-import { SET_TOUR_FEATURE, TOUR_NEXT, TOUR_RESTART } from '../constants/ActionTypes'
+import {
+  SET_TOUR_FEATURE,
+  TOUR_NEXT,
+  TOUR_RESTART,
+  TOUR_PREVIOUS,
+  RESET_ADVANCE_SOURCE,
+  SET_STEP,
+} from '../constants/ActionTypes'
 import { tour } from '../store/initialState'
+import { ACTS_TOUR } from '../constants/tour'
 
 const INITIAL_STATE = tour
 
 const tours = (dataRepairers) => (state = INITIAL_STATE, action) => {
+  const { feature, source, appInteractionAdvanced, overridenStepIndex, resetIfMismatch } = action
+
   switch (action.type) {
     case SET_TOUR_FEATURE: {
-      const newState = Object.assign({}, INITIAL_STATE)
-      newState.feature = action.payload //an object with feature: 'string', featureId: int
-      newState.showTour = true
-      return { ...state, ...newState }
-    }
-    //main tour callback
-    case TOUR_NEXT: {
-      let transitionSteps = []
-      let endStep
-      state.b2bTransition = false
-      //switch based on which tour is running -> to determine when the
-      //tour callback should delay until next step's component is mounted
-      switch (state.feature.name) {
-        case 'acts':
-          transitionSteps = [0, 4, 5, 6]
-          endStep = 9
-          break
-        default:
-          state.transitioning = false
+      return {
+        ...state,
+        feature,
+        showTour: true,
       }
-      //delay the next step until component associated with the step is mounted
-      if (transitionSteps.includes(state.stepIndex)) {
-        state.transitioning = true
-        //need to anticipate back-to-back delays
-        if (transitionSteps.includes(state.stepIndex + 1)) {
-          state.b2bTransition = true
+    }
+
+    case SET_STEP: {
+      return { ...state, stepIndex: overridenStepIndex }
+    }
+
+    case TOUR_PREVIOUS: {
+      if (!state.showTour) return state
+
+      if (source !== state.stepIndex) {
+        if (resetIfMismatch) {
+          return {
+            ...state,
+            stepIndex: 0,
+            showTour: false,
+          }
         }
-      } else {
-        state.transitioning = false
+        return state
       }
-      //increment or decrement stepIndex
-      if (action.payload === 'prev') {
-        state.stepIndex = state.stepIndex - 1
-      } else {
-        state.stepIndex = state.stepIndex + 1
+
+      const nextState = {
+        ...state,
+        stepIndex: state.stepIndex - 1,
+        appInteractionAdvanced,
       }
-      //ensure the tour runs at the next step
-      state.loading = false
-      state.run = true
-      //stop the tour at the appropriate endStep,
-      //store that they have completed this tour,
-      //clear the feature so the tour doesn't run again unless manually started
-      if (state.stepIndex === endStep) {
-        state.toursTaken[`${state.feature.name}`] = true
-        state.feature = {}
-        state.run = false
+
+      switch (feature) {
+        case ACTS_TOUR:
+          switch (state.stepIndex) {
+            case 9:
+              return {
+                ...nextState,
+                feature: null,
+                toursTaken: [...state.toursTaken, feature],
+              }
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            default:
+              return nextState
+          }
+        default:
+          return state
       }
-      state.showTour = false
-      return { ...state, state }
     }
+
+    case TOUR_NEXT: {
+      if (!state.showTour) return state
+
+      if (source !== state.stepIndex) {
+        if (resetIfMismatch) {
+          return {
+            ...state,
+            stepIndex: 0,
+            showTour: false,
+          }
+        }
+        return state
+      }
+
+      const nextState = {
+        ...state,
+        stepIndex: state.stepIndex + 1,
+        appInteractionAdvanced,
+      }
+
+      switch (feature) {
+        case ACTS_TOUR:
+          switch (state.stepIndex) {
+            case 9:
+              return {
+                ...nextState,
+                feature: null,
+                toursTaken: [...state.toursTaken, feature],
+              }
+            case 8:
+              return {
+                ...nextState,
+                stepIndex: 0,
+              }
+            case 7:
+              return {
+                ...nextState,
+                stepIndex: 9,
+              }
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            default:
+              return nextState
+          }
+        default:
+          return state
+      }
+    }
+
+    case RESET_ADVANCE_SOURCE: {
+      return {
+        ...state,
+        appInteractionAdvanced: false,
+      }
+    }
+
     case TOUR_RESTART: {
-      const newState = INITIAL_STATE
-      return { ...state, newState }
+      return INITIAL_STATE
     }
+
     default:
       return state
   }

--- a/lib/pltr/v2/store/initialState.js
+++ b/lib/pltr/v2/store/initialState.js
@@ -230,24 +230,8 @@ export const featureFlags = {}
 
 export const tour = {
   showTour: false,
-  // feature:{
-  //   name:'',
-  //   id:0,
-  //   endstep:null
-  // }, // XXXXXX use this blank object once the user can select the feature to tour
-  feature: {
-    name: 'acts',
-    id: 1,
-    endStep: 8,
-  },
-  run: true,
-  //continuous: true, // won't they all be either continuous or not? - may need to include a continuous key/value in the 'feature' object above depending on which feature, some may not be continuous
+  feature: '',
   stepIndex: 0,
-  steps: [],
-  loading: false,
-  action: 'start',
-  transitioning: false,
-  b2bTransition: false,
-  toursTaken: {},
-  // key: new Date(), // may need this to restart tours when more tours are added
+  toursTaken: [],
+  userToAdvanceManually: false,
 }

--- a/src/app/components/intros/Tour.js
+++ b/src/app/components/intros/Tour.js
@@ -1,107 +1,64 @@
 import React, { Component } from 'react'
-import { remote } from 'electron'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { actions, selectors } from 'pltr/v2'
-
-import ReactJoyride, { EVENTS } from 'react-joyride'
-
-const { tourSelector } = selectors
+import { actions, selectors, tourConstants } from 'pltr/v2'
 import { ACTS_TOUR_STEPS } from './actsTourSteps'
 
-const win = remote.getCurrentWindow()
+import ReactJoyride, { ACTIONS, EVENTS } from 'react-joyride'
+
+const { tourSelector } = selectors
+
+const { ACTS_TOUR } = tourConstants
 
 class Tour extends Component {
-  state = {
-    continuous: true,
-    loading: this.props.loading,
-    run: this.props.run,
-    steps: this.props.steps,
-    stepIndex: this.props.stepIndex,
-    transitioning: this.props.transitioning,
-    b2bTransition: this.props.b2bTransition,
-    doneTransitioning: false,
+  constructor(props) {
+    super(props)
+    this.state = {
+      steps: [],
+    }
   }
 
-  static propTypes = {
-    joyride: PropTypes.shape({
-      callback: PropTypes.func,
-    }),
-  }
-
-  static defaultProps = {
-    joyride: {},
-  }
-
-  handleClickStart = (e) => {
-    e.preventDefault()
-
-    this.setState({
-      run: true,
-      stepIndex: 0,
-    })
-  }
-
-  handleClickNextButton = () => {
-    const { stepIndex } = this.state
-
-    if (this.state.stepIndex === 1) {
-      this.setState({
-        stepIndex: stepIndex + 1,
-      })
+  componentDidMount = () => {
+    switch (this.props.tour.feature) {
+      case ACTS_TOUR:
+        this.setState({ steps: ACTS_TOUR_STEPS })
+        break
     }
   }
 
   handleJoyrideCallback = (data) => {
-    const { joyride } = this.props
-    const { action, index, type } = data
+    const { action, type } = data
+    const { tour } = this.props
 
-    if (
-      type === EVENTS.STEP_AFTER &&
-      this.props.transitioning === true &&
-      this.state.doneTransitioning === false
-    ) {
-      // IF the next step's component isn't mounted yet
-      // temporarily delay the next step so the component can mount
-      this.setState({ run: false, loading: true })
-      setTimeout(() => {
-        this.setState({
-          loading: false,
-          run: true,
-        })
-      }, 400)
-      // DON'T run the redux action TOUR_NEXT, TOUR_NEXT is triggered on click of
-      // the component the previous step targets (e.g. <button className="acts-tour-step1">
-      // in openBeatConfig in TimelineWrapper)
-      if (!this.props.b2bTransition) this.setState({ doneTransitioning: true })
-    } else if (type === EVENTS.STEP_AFTER) {
-      this.setState({ run: false, loading: true, doneTransitioning: false })
-      setTimeout(() => {
-        this.setState({
-          loading: false,
-          run: true,
-        })
-      }, 400)
-      // run the redux action TOUR_NEXT
-      this.props.actions.tourNext(action)
-      if (index === this.props.feature.endStep) win.reload()
+    if (type === EVENTS.TARGET_NOT_FOUND) {
+      // Element exists, but is invisible.  We're fine with that!
+      if (document.querySelector(data.step.target)) return
+      this.props.actions.setStep(8)
+      return
     }
 
-    if (typeof joyride.callback === 'function') {
-      joyride.callback(data)
-    } else {
-      // console.group(type,'type');
-      // console.log(data,'data'); //eslint-disable-line no-console
-      // console.groupEnd();
+    if (action === ACTIONS.NEXT && type === EVENTS.STEP_AFTER) {
+      if (tour.appInteractionAdvanced) {
+        this.props.actions.resetAdvanceSource()
+      } else {
+        this.props.actions.tourNext(tour.feature, tour.stepIndex, false)
+      }
     }
   }
 
   render() {
+    const { showTour, stepIndex } = this.props.tour
+
     return (
       <ReactJoyride
+        disableCloseOnEsc
         scrollToFirstStep
-        {...this.props}
+        hideCloseButton
+        continuous
+        showTour={showTour}
+        stepIndex={stepIndex}
+        steps={this.state.steps}
         callback={this.handleJoyrideCallback}
         styles={{
           options: {
@@ -112,7 +69,7 @@ class Tour extends Component {
             borderWidth: 0,
           },
           buttonBack: {
-            color: '#ff9466',
+            display: 'none',
           },
           tooltipTitle: {
             color: 'black',
@@ -124,27 +81,12 @@ class Tour extends Component {
 }
 
 Tour.propTypes = {
-  tour: PropTypes.object,
-  loading: PropTypes.bool.isRequired,
-  run: PropTypes.bool.isRequired,
-  steps: PropTypes.array.isRequired,
-  stepIndex: PropTypes.number.isRequired,
-  transitioning: PropTypes.bool,
-  b2bTransition: PropTypes.bool,
+  tour: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired,
-  feature: PropTypes.object.isRequired,
 }
 
 function mapStateToProps(state) {
-  // this determines which steps the tour should follow based on which feature is being toured
-  switch (state.present.tour.feature.name) {
-    case 'acts':
-      state.present.tour.steps = ACTS_TOUR_STEPS
-      break
-    default:
-      state.present.tour.run = false
-  }
-  return tourSelector(state.present)
+  return { tour: tourSelector(state.present) }
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/app/components/intros/actsTourSteps.js
+++ b/src/app/components/intros/actsTourSteps.js
@@ -19,18 +19,10 @@ export const ACTS_TOUR_STEPS = [
     target: `.acts-tour-step2`,
     title: 'Adding Levels of Structure',
     content:
-      "Click the '+' to add levels. This will place your top row timeline cards in their own defined sections. You can have up to three (3) levels for optimal visual arrangement, and can even make cards for entire sections. Think of the second level as a way to organize your top row cards (which will become 'Scenes') into chapters and the third level to organize your chapters into acts, adding layers of specificity and structure to your Plottr project.",
+      "Click the '+' to add levels. This will place your top row timeline cards in their own defined sections. You can have up to three (3) levels.  You can create scene which correspond to each level. Think of the second level as a way to organize your top row cards (which will become 'Scenes') into chapters and the third level to organize your chapters into acts, adding layers of specificity and structure to your Plottr project.",
     placement: 'bottom',
     event: 'hover',
     spotlightClicks: true,
-    styles: {
-      buttonBack: {
-        display: 'none',
-      },
-      buttonNext: {
-        display: 'none',
-      },
-    },
   },
   {
     target: `.acts-tour-step3`,
@@ -52,20 +44,14 @@ export const ACTS_TOUR_STEPS = [
   },
   {
     target: `.acts-tour-step5`,
-    title: 'Take Plottr to the next level!',
-    content: 'Make sure you have added levels or the tour will end here.',
+    title: 'Adding Acts and Chapters',
+    content: 'Click here to return to the timeline',
     event: 'hover',
     spotlightClicks: true,
-    placement: 'right',
+    disableBeacon: true,
     styles: {
-      buttonBack: {
-        display: 'none',
-      },
       buttonNext: {
         display: 'none',
-      },
-      options: {
-        zIndex: 0,
       },
     },
   },
@@ -77,11 +63,11 @@ export const ACTS_TOUR_STEPS = [
     event: 'hover',
     spotlightClicks: true,
     styles: {
-      buttonBack: {
-        display: 'none',
-      },
       buttonNext: {
         display: 'none',
+      },
+      options: {
+        zIndex: 10,
       },
     },
   },
@@ -93,9 +79,6 @@ export const ACTS_TOUR_STEPS = [
     event: 'hover',
     spotlightClicks: true,
     styles: {
-      buttonBack: {
-        display: 'none',
-      },
       buttonNext: {
         display: 'none',
       },
@@ -106,7 +89,23 @@ export const ACTS_TOUR_STEPS = [
     title: 'Adding Lower-Level Cards',
     content: `Click here to add lower-level cards within their parent section. Cards can be dragged and dropped onto/next to cards of the same level or one level up.`,
     event: 'hover',
-    // spotlightClicks: false,
+    spotlightClicks: true,
+    hideCloseButton: true,
+    styles: {
+      buttonNext: {
+        display: 'none',
+      },
+    },
+  },
+  {
+    target: `body`,
+    title: 'You need at lest one level of structure to continue',
+    content: 'Please mkae sure that you add a level of hierarchy',
+    event: 'hover',
+    placement: 'bottom',
+    spotlightClicks: true,
+    hideCloseButton: true,
+    disableBeacon: true,
   },
   {
     target: `.tour-end`,
@@ -114,10 +113,5 @@ export const ACTS_TOUR_STEPS = [
     spotlightClicks: false,
     disableBeacon: true,
     placement: 'center',
-    styles: {
-      buttonBack: {
-        display: 'none',
-      },
-    },
   },
 ]

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'react-proptypes'
 import Navigation from 'containers/Navigation'
 import Body from 'containers/Body'
-import ActsTour from '../components/intros/Tour'
+import Tour from '../components/intros/Tour'
 import { AskToSaveModal, TemplateCreate, ErrorBoundary } from 'connected-components'
 import { hasPreviousAction } from '../../common/utils/error_reporter'
 import { saveFile } from '../../common/utils/files'
@@ -114,14 +114,7 @@ class App extends Component {
   }
 
   renderGuidedTour() {
-    let feature = store.getState().present.tour.feature.name
-    if (!feature) return null
-    if (
-      store.getState().present.featureFlags.BEAT_HIERARCHY && //in the future can include a switch(feature) which if case('acts') -> tourConditions = true --- if tourConditions true then the tour will run
-      feature
-    )
-      return <ActsTour />
-    return null
+    return <Tour />
   }
 
   render() {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -10,7 +10,7 @@ import { ipcRenderer, remote } from 'electron'
 import electron from 'electron'
 const { app, dialog } = remote
 const win = remote.getCurrentWindow()
-import { actions, migrateIfNeeded, featureFlags } from 'pltr/v2'
+import { actions, migrateIfNeeded, featureFlags, tourConstants } from 'pltr/v2'
 import MPQ from '../common/utils/MPQ'
 import { ensureBackupTodayPath, saveBackup } from '../common/utils/backup'
 import setupRollbar from '../common/utils/rollbar'
@@ -241,7 +241,7 @@ ipcRenderer.on('redo', (event) => {
 })
 
 ipcRenderer.on('acts-tour-start', (event) => {
-  store.dispatch(actions.tour.setTourFeature({ name: 'acts', id: 1, endStep: 8 }))
+  store.dispatch(actions.tour.setTourFeature(tourConstants.ACTS_TOUR))
 })
 
 window.onerror = function (message, file, line, column, err) {


### PR DESCRIPTION
After the rebasing from `tour-fixes-5-17-release` to remove extraneous commits didn't work, I made a new branch from the current `staging` and inserted the updated tour code. The important change here is the conditional calling of `tourNext()` in the `ActsConfigModal` `useEffect` on line 58. I have not been able to recreate any of @Quiescent's errors noted here: https://user-images.githubusercontent.com/1457336/119347621-0b927600-bc9c-11eb-936c-e3d30e07b5ab.mp4

My thoughts being we can release the tour in any upcoming patch releases as-is prior to shifting the tour functionality to a Fixed State Machine for greater simplicity in the tour reducer.

re: https://github.com/cameronsutter/plottr_electron/pull/661#issuecomment-847012249 