### PR TITLE
Track all migrations

### DIFF
--- a/lib/pltr/v2/migrator/__tests__/greaterBySemver.test.js
+++ b/lib/pltr/v2/migrator/__tests__/greaterBySemver.test.js
@@ -1,0 +1,28 @@
+import { greaterBySemver } from '../greaterBySemver'
+
+describe('greaterBySemver', () => {
+  describe('given two empty versions', () => {
+    it('should throw an exception because *a* version is invalid', () => {
+      expect(() => {
+        greaterBySemver('', '')
+      }).toThrow()
+    })
+  })
+  describe('given m2021_2_3', () => {
+    describe('and m2021_3_3', () => {
+      it('should produce false', () => {
+        expect(greaterBySemver('m2021_2_3', 'm2021_3_3')).toEqual(false)
+      })
+    })
+    describe('and m2021_2_3', () => {
+      it('should produce false', () => {
+        expect(greaterBySemver('m2021_2_3', 'm2021_2_3')).toEqual(false)
+      })
+    })
+    describe('and m2021_1_20', () => {
+      it('should produce true', () => {
+        expect(greaterBySemver('m2021_2_3', 'm2021_1_20')).toEqual(true)
+      })
+    })
+  })
+})

--- a/lib/pltr/v2/migrator/__tests__/migrator.test.js
+++ b/lib/pltr/v2/migrator/__tests__/migrator.test.js
@@ -1,0 +1,28 @@
+import Migrator from '../migrator'
+
+import { state_2021_2_8, state_2021_6_9 } from '../migrations/__tests__/fixtures'
+
+describe('migrator', () => {
+  describe('given a v2021.2.8 file', () => {
+    describe('without an `initialVersion` or `appliedMigrations`', () => {
+      it('should add `initialVersion` of 2021.2.8', async () => {
+        const migrator = new Migrator(state_2021_2_8, 'test', '2021.2.8', '2021.6.9')
+        const data = await new Promise((resolve) =>
+          migrator.migrate((err, result) => {
+            resolve(result)
+          })
+        )
+        expect(data.file.initialVersion).toEqual('2021.2.8')
+      })
+      it('should add `appliedMigrations` of [m2021_4_13, m2021_6_9]', async () => {
+        const migrator = new Migrator(state_2021_2_8, 'test', '2021.2.8', '2021.6.9')
+        const data = await new Promise((resolve) =>
+          migrator.migrate((err, result) => {
+            resolve(result)
+          })
+        )
+        expect(data.file.appliedMigrations).toEqual(['m2021_4_13', 'm2021_6_9'])
+      })
+    })
+  })
+})

--- a/lib/pltr/v2/migrator/__tests__/migrator.test.js
+++ b/lib/pltr/v2/migrator/__tests__/migrator.test.js
@@ -47,5 +47,28 @@ describe('migrator', () => {
         expect(data.file.appliedMigrations).toEqual([])
       })
     })
+    describe('with an `initialVersion` of 2021.4.13', () => {
+      it('should apply 2021.6.9', async () => {
+        const migrator = new Migrator(
+          {
+            ...state_2021_2_8,
+            file: {
+              ...state_2021_2_8.file,
+              initialVersion: '2021.4.13',
+              appliedMigrations: [],
+            },
+          },
+          'test',
+          '2021.2.8',
+          '2021.6.9'
+        )
+        const data = await new Promise((resolve) =>
+          migrator.migrate((err, result) => {
+            resolve(result)
+          })
+        )
+        expect(data.file.appliedMigrations).toEqual(['m2021_6_9'])
+      })
+    })
   })
 })

--- a/lib/pltr/v2/migrator/__tests__/migrator.test.js
+++ b/lib/pltr/v2/migrator/__tests__/migrator.test.js
@@ -70,5 +70,35 @@ describe('migrator', () => {
         expect(data.file.appliedMigrations).toEqual(['m2021_6_9'])
       })
     })
+    describe('with an `initialVersion` of 2021.2.8', () => {
+      describe('and the 2021.6.9 migration applied, but not the 2021.4.13', () => {
+        it('should throw an error', async () => {
+          const migrator = new Migrator(
+            {
+              ...state_2021_2_8,
+              file: {
+                ...state_2021_2_8.file,
+                initialVersion: '2021.2.8',
+                appliedMigrations: ['m2021_6_9'],
+              },
+            },
+            'test',
+            '2021.2.8',
+            '2021.6.9'
+          )
+          let success = false
+          try {
+            await new Promise((resolve) =>
+              migrator.migrate((err, result) => {
+                resolve(result)
+              })
+            )
+          } catch (e) {
+            success = true
+          }
+          expect(success).toEqual(true)
+        })
+      })
+    })
   })
 })

--- a/lib/pltr/v2/migrator/__tests__/migrator.test.js
+++ b/lib/pltr/v2/migrator/__tests__/migrator.test.js
@@ -24,5 +24,28 @@ describe('migrator', () => {
         expect(data.file.appliedMigrations).toEqual(['m2021_4_13', 'm2021_6_9'])
       })
     })
+    describe('with an `initialVersion` of 2021.6.9', () => {
+      it('should not apply any more migrations', async () => {
+        const migrator = new Migrator(
+          {
+            ...state_2021_2_8,
+            file: {
+              ...state_2021_2_8.file,
+              initialVersion: '2021.6.9',
+              appliedMigrations: [],
+            },
+          },
+          'test',
+          '2021.2.8',
+          '2021.6.9'
+        )
+        const data = await new Promise((resolve) =>
+          migrator.migrate((err, result) => {
+            resolve(result)
+          })
+        )
+        expect(data.file.appliedMigrations).toEqual([])
+      })
+    })
   })
 })

--- a/lib/pltr/v2/migrator/greaterBySemver.js
+++ b/lib/pltr/v2/migrator/greaterBySemver.js
@@ -1,0 +1,6 @@
+import semverGt from 'semver/functions/gt'
+
+import { toSemver } from './toSemver'
+
+export const greaterBySemver = (thisVersion, thatVersion) =>
+  semverGt(toSemver(thisVersion), toSemver(thatVersion))

--- a/lib/pltr/v2/migrator/migrations_list.js
+++ b/lib/pltr/v2/migrator/migrations_list.js
@@ -1,3 +1,5 @@
+import { greaterBySemver } from './greaterBySemver'
+
 const list = [
   'm0_6',
   'm0_7',
@@ -23,4 +25,6 @@ const list = [
   'm2021_6_9',
 ]
 
-export default list
+export default list.sort((thisVersion, thatVersion) =>
+  greaterBySemver(thisVersion, thatVersion) ? 1 : -1
+)

--- a/lib/pltr/v2/migrator/migrator.js
+++ b/lib/pltr/v2/migrator/migrator.js
@@ -1,9 +1,13 @@
-import { cloneDeep, difference } from 'lodash'
+import { cloneDeep, difference, first, last } from 'lodash'
 import semverGt from 'semver/functions/gt'
 import semverEq from 'semver/functions/eq'
 import semverCoerce from 'semver/functions/coerce'
 import migrationsList from './migrations_list'
 import migrators from './migrations'
+
+const toSemver = (version) => {
+  return semverCoerce(version.replace('m', '').replace(/_/g, '.'))
+}
 
 export default function Migrator(data, fileName, fileVersion, appVersion, backupFunction) {
   this.data = cloneDeep(data)
@@ -71,11 +75,21 @@ export default function Migrator(data, fileName, fileVersion, appVersion, backup
 
     this.migrations = migrationsList.filter((version) => {
       if (!this.fileVersion) return true
-      const usableVersionString = version.replace('m', '').replace(/_/g, '.')
       const initialVersion = this.data.file.initialVersion
-      return semverGt(semverCoerce(usableVersionString), initialVersion)
+      return semverGt(toSemver(version), initialVersion)
     })
-    this.migrations = difference(this.migrations, this.data.file.appliedMigrations)
+    const appliedMigrations = this.data.file.appliedMigrations
+    this.migrations = difference(this.migrations, appliedMigrations)
+    if (appliedMigrations && appliedMigrations.length && this.migrations.length) {
+      const latestAppliedMigration = toSemver(last(appliedMigrations))
+      const firstMigrationToApply = toSemver(first(this.migrations))
+      if (semverGt(latestAppliedMigration, firstMigrationToApply)) {
+        throw new Error(
+          `Can't migrate from version ${latestAppliedMigration} to version
+${firstMigrationToApply}`
+        )
+      }
+    }
     this.migrationsChecked = true
     return this.migrations
   }

--- a/lib/pltr/v2/migrator/migrator.js
+++ b/lib/pltr/v2/migrator/migrator.js
@@ -1,13 +1,9 @@
 import { cloneDeep, difference, first, last } from 'lodash'
 import semverGt from 'semver/functions/gt'
 import semverEq from 'semver/functions/eq'
-import semverCoerce from 'semver/functions/coerce'
 import migrationsList from './migrations_list'
 import migrators from './migrations'
-
-const toSemver = (version) => {
-  return semverCoerce(version.replace('m', '').replace(/_/g, '.'))
-}
+import { toSemver } from './toSemver'
 
 export default function Migrator(data, fileName, fileVersion, appVersion, backupFunction) {
   this.data = cloneDeep(data)

--- a/lib/pltr/v2/migrator/migrator.js
+++ b/lib/pltr/v2/migrator/migrator.js
@@ -1,6 +1,5 @@
 import { cloneDeep, difference, first, last } from 'lodash'
 import semverGt from 'semver/functions/gt'
-import semverEq from 'semver/functions/eq'
 import migrationsList from './migrations_list'
 import migrators from './migrations'
 import { toSemver } from './toSemver'
@@ -50,14 +49,9 @@ export default function Migrator(data, fileName, fileVersion, appVersion, backup
     callback(null, this.data)
   }
 
-  this.areDifferentVersions = function () {
-    if (!this.fileVersion) return false
-    return !semverEq(this.fileVersion, this.appVersion)
-  }
-
   this.needsToMigrate = function () {
     if (!this.fileVersion) return false
-    return this.areDifferentVersions() && this.getMigrations().length
+    return this.getMigrations().length
   }
 
   this.plottrBehindFile = function () {

--- a/lib/pltr/v2/migrator/migrator.js
+++ b/lib/pltr/v2/migrator/migrator.js
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash'
+import { cloneDeep, difference } from 'lodash'
 import semverGt from 'semver/functions/gt'
 import semverEq from 'semver/functions/eq'
 import semverCoerce from 'semver/functions/coerce'
@@ -12,6 +12,10 @@ export default function Migrator(data, fileName, fileVersion, appVersion, backup
   this.migrations = []
   this.migrationsChecked = false
   this.backupFunction = backupFunction
+
+  if (!this.data.file.initialVersion) {
+    this.data.file.initialVersion = this.fileVersion
+  }
 
   this.migrate = function (callback) {
     // save a backup file
@@ -35,9 +39,6 @@ export default function Migrator(data, fileName, fileVersion, appVersion, backup
 
   this.startMigrations = function (callback) {
     let migrations = this.getMigrations()
-    if (!this.data.file.initialVersion) {
-      this.data.file.initialVersion = this.fileVersion
-    }
     migrations.forEach((m) => {
       this.data = migrators[m](this.data)
       if (!this.data.file.appliedMigrations) {
@@ -71,8 +72,10 @@ export default function Migrator(data, fileName, fileVersion, appVersion, backup
     this.migrations = migrationsList.filter((version) => {
       if (!this.fileVersion) return true
       const usableVersionString = version.replace('m', '').replace(/_/g, '.')
-      return semverGt(semverCoerce(usableVersionString), this.fileVersion)
+      const initialVersion = this.data.file.initialVersion
+      return semverGt(semverCoerce(usableVersionString), initialVersion)
     })
+    this.migrations = difference(this.migrations, this.data.file.appliedMigrations)
     this.migrationsChecked = true
     return this.migrations
   }

--- a/lib/pltr/v2/migrator/migrator.js
+++ b/lib/pltr/v2/migrator/migrator.js
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash'
 import semverGt from 'semver/functions/gt'
 import semverEq from 'semver/functions/eq'
 import semverCoerce from 'semver/functions/coerce'
@@ -5,7 +6,7 @@ import migrationsList from './migrations_list'
 import migrators from './migrations'
 
 export default function Migrator(data, fileName, fileVersion, appVersion, backupFunction) {
-  this.data = data
+  this.data = cloneDeep(data)
   this.fileVersion = fileVersion
   this.appVersion = appVersion
   this.migrations = []
@@ -34,8 +35,15 @@ export default function Migrator(data, fileName, fileVersion, appVersion, backup
 
   this.startMigrations = function (callback) {
     let migrations = this.getMigrations()
+    if (!this.data.file.initialVersion) {
+      this.data.file.initialVersion = this.fileVersion
+    }
     migrations.forEach((m) => {
       this.data = migrators[m](this.data)
+      if (!this.data.file.appliedMigrations) {
+        this.data.file.appliedMigrations = []
+      }
+      this.data.file.appliedMigrations.push(m)
     })
     this.data.file.version = this.appVersion
     callback(null, this.data)

--- a/lib/pltr/v2/migrator/toSemver.js
+++ b/lib/pltr/v2/migrator/toSemver.js
@@ -1,0 +1,5 @@
+import semverCoerce from 'semver/functions/coerce'
+
+export const toSemver = (version) => {
+  return semverCoerce(version.replace('m', '').replace(/_/g, '.'))
+}

--- a/main/modules/menus/file.js
+++ b/main/modules/menus/file.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const i18n = require('plottr_locales').t
-const { app, dialog, shell } = require('electron')
+const { app, shell } = require('electron')
 const { is } = require('electron-util')
 const { getWindowById, numberOfWindows } = require('../windows')
 const { NODE_ENV } = require('../constants')

--- a/src/dashboard/components/files/NewFiles.js
+++ b/src/dashboard/components/files/NewFiles.js
@@ -6,7 +6,7 @@ import { t } from 'plottr_locales'
 import cx from 'classnames'
 import { createNew, openExistingFile } from '../../utils/window_manager'
 import MPQ from '../../../common/utils/MPQ'
-import { Col, Grid, Row, Clearfix } from 'react-bootstrap'
+import { Col, Grid, Row } from 'react-bootstrap'
 import log from 'electron-log'
 import { remote } from 'electron'
 const { dialog } = remote

--- a/src/dashboard/components/options/OptionsHome.js
+++ b/src/dashboard/components/options/OptionsHome.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import electron, { ipcRenderer, shell } from 'electron'
 import { t, setupI18n } from 'plottr_locales'
 import SETTINGS from '../../../common/utils/settings'
@@ -15,25 +15,6 @@ export default function OptionsHome(props) {
 
   const [backupLocation, setBackupLocation] = useState(settings.user.backupLocation)
   if (!backupLocation || backupLocation == 'default') setBackupLocation(BACKUP_BASE_PATH)
-
-  const [loading, setLoading] = useState(false)
-  const [preloading, setPreloading] = useState(false)
-
-  const [loop, setLoop] = useState()
-  const [message, setMessage] = useState(false)
-
-  useEffect(() => {
-    setLoop(
-      setInterval(() => {
-        if (preloading && loading) {
-          setMessage(true)
-        }
-      }, 5000)
-    )
-    return function cleanup() {
-      clearInterval(loop)
-    }
-  }, [preloading, loading])
 
   // const onChangeBackupLocation = (event) => {
   //   let file = event.target.files[0]
@@ -78,15 +59,7 @@ export default function OptionsHome(props) {
   }
 
   return (
-    <div
-      className="dashboard__options"
-      onFocus={() => {
-        if (preloading) setLoading(true)
-      }}
-      onBlur={() => {
-        if (!preloading) setLoading(false)
-      }}
-    >
+    <div className="dashboard__options">
       <h1>{t('Settings')}</h1>
       <div>
         <div className="dashboard__options__item">


### PR DESCRIPTION
# Motivation
Whenever we change the schema of Plottr files in a way that requires changes to be made as the app loads, we migrate the file from the old version to the new version.
Previously it was possible to miss migrations when Plottr creates files while we're still testing, and then we bump the version of Plottr for releasing.
In this PR, we add two properties to the `file` attribute on `pltr` files:
 - `initialVersion` (the first version that we migrated from ever), and
 - `appliedMigrations` (a list of all of the migrations that we've ever applied to the file.)
 
The algorithm for finding migrations is slightly different now:
 - find all migrations after the `initialVersion`,
 - take out all migrations already applied,
 - if the first migration is before the latest applied migration, then throw an error (because one of the earlier migrations was missed(!)), and
 - apply migrations.

This PR includes tests for various migration scenarios.