### PR TITLE
Fix the root RCE normaliser for string attributes which became para

### DIFF
--- a/lib/plottr_components/src/components/rce/Normalizer.js
+++ b/lib/plottr_components/src/components/rce/Normalizer.js
@@ -67,6 +67,20 @@ const withNormalizer = (editor) => {
 }
 
 export const normalize = (content) => {
+  // Some RCE content is actually text that has not been modified yet.
+  if (content.constructor !== Array) {
+    return [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: content,
+          },
+        ],
+      },
+    ]
+  }
+
   const editor = withNormalizer(createEditor())
   editor.children = content
   Editor.normalize(editor, { force: true })


### PR DESCRIPTION
# Problem
When we change attribute types, we don't greedily change the existing attributes; this means that the normaliser might find text and think it's RCE content because the attribute type changed, but the attribute value didn't.

# Proposed Fix
When we normalise RCE data, first check whether the data is an Array.
If the data is an array, then normalise it, otherwise turn it into a single-line paragraph.