### PR TITLE
Implement default colors for the structure feature

### DIFF
--- a/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
+++ b/lib/plottr_components/src/components/dialogs/EditOrDisplay.js
@@ -10,6 +10,14 @@ import ColorPickerColor from '../ColorPickerColor'
 const EditOrDisplayConnector = (connector) => {
   const ColorPicker = UnconnectedColorPicker(connector)
 
+  const {
+    pltr: {
+      helpers: {
+        colors: { getTextColor },
+      },
+    },
+  } = connector
+
   const EditOrDisplay = ({
     id,
     editing,
@@ -20,6 +28,7 @@ const EditOrDisplayConnector = (connector) => {
     options,
     hideArrow,
     addSpacer,
+    isDarkMode,
   }) => {
     const [stagedValue, setStagedValue] = useState(value)
     useEffect(() => {
@@ -113,7 +122,7 @@ const EditOrDisplayConnector = (connector) => {
           return (
             <div className="acts-modal__levels-table-cell">
               <ColorPickerColor
-                color={value || '#F1F5F8'} // $gray-9
+                color={getTextColor(value, isDarkMode)}
                 choose={() => {
                   setEditing(true)
                 }}
@@ -169,12 +178,23 @@ const EditOrDisplayConnector = (connector) => {
     type: PropTypes.string.isRequired,
     setValue: PropTypes.func.isRequired,
     setEditing: PropTypes.func.isRequired,
+    isDarkMode: PropTypes.bool.isRequired,
     options: PropTypes.array,
     hideArrow: PropTypes.bool,
     addSpacer: PropTypes.bool,
   }
 
-  return EditOrDisplay
+  const { redux } = connector
+
+  if (redux) {
+    const { connect } = redux
+
+    return connect((state) => ({
+      isDarkMode: state.present.ui.darkMode,
+    }))(EditOrDisplay)
+  }
+
+  throw new Error('Could not connect EditOrDisplay')
 }
 
 export default EditOrDisplayConnector

--- a/lib/plottr_components/src/components/timeline/BeatTitleCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatTitleCell.js
@@ -541,7 +541,8 @@ const BeatTitleCellConnector = (connector) => {
                     this.state.inDropZone,
                   this.props.ui.darkMode === true
                     ? this.props.hierarchyLevel.dark
-                    : this.props.hierarchyLevel.light
+                    : this.props.hierarchyLevel.light,
+                  ui.darkMode
                 )}
                 className={innerKlass}
                 onClick={this.startEditing}

--- a/lib/pltr/v2/helpers/colors.js
+++ b/lib/pltr/v2/helpers/colors.js
@@ -1,8 +1,17 @@
 import tinycolor from 'tinycolor2'
 
+const defaultLightModeText = '#0b1117'
+const defaultDarkModeText = '#eee'
+
 // returns [useBlack, value]
 export const getContrastYIQ = (color) => {
   const brightness = tinycolor(color).getBrightness()
   // >= 125 is the recommended functionality
   return [brightness >= 180, brightness]
+}
+
+export const getTextColor = (color, isDarkMode) => {
+  if (color !== 'none') return color
+
+  return isDarkMode ? defaultDarkModeText : defaultLightModeText
 }

--- a/lib/pltr/v2/helpers/hierarchy.js
+++ b/lib/pltr/v2/helpers/hierarchy.js
@@ -3,6 +3,8 @@ import { DASHED, DOTTED, nextBorderStyle, NONE, SOLID } from '../store/borderSty
 import { hierarchyLevel } from '../store/initialState'
 import { t } from 'plottr_locales'
 
+import { getTextColor } from './colors'
+
 export const borderStyleToCss = (borderStyle) => {
   switch (borderStyle) {
     case NONE:
@@ -28,10 +30,11 @@ export const hierarchyToStyles = (
   { level, textSize, borderStyle, backgroundColor },
   timelineSize,
   hovering,
-  theme
+  theme,
+  isDarkMode
 ) => ({
   ...{
-    color: nullIfNone(theme.textColor),
+    color: nullIfNone(getTextColor(theme.textColor, isDarkMode)),
     lineHeight: `${textSize}px`,
     backgroundColor: nullIfNone(backgroundColor),
   },


### PR DESCRIPTION
# Motivation: to port @jeanawhou 's PR to the dark/light themes
A while ago, both @murfdog64 and @jeanawhou wrote PRs to handle the difference in text colour between dark and light mode in the act config modal.
Both approaches are useful:
 - the one that's been merged created two "themes" so that the user can control colours for light versus dark mode independently,
 - this one selects better default colours when no colour is selected.

I'm closing https://github.com/cameronsutter/plottr_electron/pull/632 in favour of this PR.
(All I've done here is extract the changes to make them on top of the latest staging.)