### PR TITLE
Implement a much faster version of the beatIndexSelector

### DIFF
--- a/lib/pltr/v2/helpers/__tests__/beats.test.js
+++ b/lib/pltr/v2/helpers/__tests__/beats.test.js
@@ -6,6 +6,7 @@ import {
   removeLevelFromHierarchy,
   adjustHierarchyLevels,
   maxDepth,
+  numberOfPriorChildrenAtSameDepth,
 } from '../beats'
 
 describe('addLevelToHierarchy', () => {
@@ -256,6 +257,158 @@ describe('adjustHierarchyLevels', () => {
         const newTree = adjustHierarchyLevels(3)(complicatedTree, 6, 1)
 
         expect(maxDepth(newTree)).toEqual(2)
+      })
+    })
+  })
+})
+
+describe('numberOfPriorChildrenAtSameDepth', () => {
+  describe('given no beats', () => {
+    const emptyTree = { children: { null: [] }, heap: {}, index: {} }
+    const emptySortedBeats = []
+    describe('and the beat id 0', () => {
+      it('should produce null', () => {
+        expect(numberOfPriorChildrenAtSameDepth(emptyTree, emptySortedBeats, 0)).toEqual(null)
+      })
+    })
+  })
+  describe('given one beat', () => {
+    const beat = { id: 1 }
+    const singletonTree = { children: { null: [1], 1: [] }, heap: { 1: null }, index: { 1: beat } }
+    const singletonSortedBeats = [beat]
+    describe('and a beat id which is not it', () => {
+      it('should produce null', () => {
+        expect(numberOfPriorChildrenAtSameDepth(singletonTree, singletonSortedBeats, 0)).toEqual(
+          null
+        )
+      })
+    })
+    describe('and a beat id which is it', () => {
+      it('should produce 1', () => {
+        expect(numberOfPriorChildrenAtSameDepth(singletonTree, singletonSortedBeats, 1)).toEqual(1)
+      })
+    })
+  })
+  describe('given two beats', () => {
+    describe('at the same level', () => {
+      const beatOne = { id: 1 }
+      const beatTwo = { id: 2 }
+      const twoBeatTree = {
+        children: { null: [1, 2], 1: [], 2: [] },
+        heap: { 1: null, 2: null },
+        index: { 1: beatOne, 2: beatTwo },
+      }
+      const twoSortedBeats = [beatOne, beatTwo]
+      describe('and the id of the first', () => {
+        it('should produce 1', () => {
+          expect(numberOfPriorChildrenAtSameDepth(twoBeatTree, twoSortedBeats, 1)).toEqual(1)
+        })
+      })
+      describe('and the id of the second', () => {
+        it('should produce 2', () => {
+          expect(numberOfPriorChildrenAtSameDepth(twoBeatTree, twoSortedBeats, 2)).toEqual(2)
+        })
+      })
+    })
+    describe('where the second is a child of the first', () => {
+      const beatOne = { id: 1 }
+      const beatTwo = { id: 2 }
+      const twoBeatTree = {
+        children: { null: [1], 1: [2], 2: [] },
+        heap: { 1: null, 2: 1 },
+        index: { 1: beatOne, 2: beatTwo },
+      }
+      const twoSortedBeats = [beatOne, beatTwo]
+      describe('and the id of the first', () => {
+        it('should produce 1', () => {
+          expect(numberOfPriorChildrenAtSameDepth(twoBeatTree, twoSortedBeats, 1)).toEqual(1)
+        })
+      })
+      describe('and the id of the second', () => {
+        it('should produce 1', () => {
+          expect(numberOfPriorChildrenAtSameDepth(twoBeatTree, twoSortedBeats, 2)).toEqual(1)
+        })
+      })
+    })
+  })
+  describe('given a tree with many branches', () => {
+    describe('and ids at positions in those branches', () => {
+      const tree = {
+        children: {
+          null: [0, 1, 7, 8],
+          0: [],
+          1: [2],
+          2: [3, 5],
+          3: [4],
+          4: [],
+          5: [6],
+          6: [],
+          7: [],
+          8: [9],
+          9: [10, 11],
+          10: [],
+          11: [12],
+          12: [],
+        },
+        heap: {
+          0: null,
+          1: null,
+          2: 1,
+          3: 2,
+          4: 3,
+          5: 2,
+          6: 5,
+          7: null,
+          8: null,
+          9: 8,
+          10: 9,
+          11: 9,
+          12: 11,
+        },
+        index: {
+          0: { id: 0 },
+          1: { id: 1 },
+          2: { id: 2 },
+          3: { id: 3 },
+          4: { id: 4 },
+          5: { id: 5 },
+          6: { id: 6 },
+          7: { id: 7 },
+          8: { id: 8 },
+          9: { id: 9 },
+          10: { id: 10 },
+          11: { id: 11 },
+          12: { id: 12 },
+        },
+      }
+      const sortedBeats = [
+        { id: 0 },
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+        { id: 5 },
+        { id: 6 },
+        { id: 7 },
+        { id: 8 },
+        { id: 9 },
+        { id: 10 },
+        { id: 11 },
+        { id: 12 },
+      ]
+      it('correctly computes the index based on prior children at the same depth', () => {
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 1)).toEqual(2)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 2)).toEqual(1)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 3)).toEqual(1)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 4)).toEqual(1)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 5)).toEqual(2)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 6)).toEqual(2)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 7)).toEqual(3)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 8)).toEqual(4)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 9)).toEqual(2)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 10)).toEqual(3)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 11)).toEqual(4)
+        expect(numberOfPriorChildrenAtSameDepth(tree, sortedBeats, 12)).toEqual(3)
       })
     })
   })

--- a/lib/pltr/v2/helpers/beats.js
+++ b/lib/pltr/v2/helpers/beats.js
@@ -238,13 +238,20 @@ export const beatsByPosition = (predicate) => (beats) => {
   return iter(beats, null)
 }
 
-export const numberOfPriorChildrenAtSameDepth = (beatTree, beatId) => {
+export const numberOfPriorChildrenAtSameDepth = (beatTree, beats, beatId) => {
+  if (beats.length === 0) return null
   const beatDepth = tree.depth(beatTree, beatId)
-  const beatsAtLeastAsDeap = beatsByPosition((beat) => tree.depth(beatTree, beat.id) <= beatDepth)
-  return (
-    1 +
-    beatsAtLeastAsDeap(beatTree)
-      .filter((beat) => tree.depth(beatTree, beat.id) === beatDepth)
-      .findIndex((beat) => beat.id === beatId)
-  )
+  let priorChildren = 0
+  let found = false
+  for (let i = 0; i < beats.length; ++i) {
+    const { id } = beats[i]
+    const otherBeatDepth = tree.depth(beatTree, id)
+    if (id === beatId) {
+      found = true
+      break
+    }
+    if (otherBeatDepth === beatDepth) ++priorChildren
+  }
+  if (!found) return null
+  return 1 + priorChildren
 }

--- a/lib/pltr/v2/selectors/beats.js
+++ b/lib/pltr/v2/selectors/beats.js
@@ -86,6 +86,7 @@ export const beatHasChildrenSelector = createSelector(beatsByBookSelector, (beat
 
 export const beatIndexSelector = createSelector(
   beatsByBookSelector,
+  sortedBeatsByBookSelector,
   beatIdSelector,
   numberOfPriorChildrenAtSameDepth
 )


### PR DESCRIPTION
Re-wire old beats selector

Caching the sorted beats will improve things a lot!

Add a failing test for the new beat index helper

Handle the case that there are no beats

Update desired logic for indices of beats in edge cases

Add a failing test for the two beat tree

Fix the not-found return value

Implement tracking of beats at a certain depth

Add a test for indices in a general tree structure