### PR TITLE
Remove hover style for "last inserted" element

### DIFF
--- a/lib/plottr_components/src/components/timeline/BeatTitleCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatTitleCell.js
@@ -418,11 +418,7 @@ const BeatTitleCellConnector = (connector) => {
       const { hovering, inDropZone } = this.state
       const innerKlass = cx(orientedClassName('beat__body', orientation), {
         'medium-timeline': isMedium,
-        hover:
-          hovering === this.props.beat.id ||
-          this.props.beat.id ===
-            Object.values(this.props.beats.index)[Object.values(this.props.beats.index).length - 1]
-              .id,
+        hover: hovering === this.props.beat.id,
         dropping: inDropZone,
       })
       const beatKlass = cx(orientedClassName('beat__cell', orientation), {
@@ -490,12 +486,7 @@ const BeatTitleCellConnector = (connector) => {
                 style={hierarchyToStyles(
                   this.props.hierarchyLevel,
                   timelineSize,
-                  this.props.beat.id ===
-                    Object.values(this.props.beats.index)[
-                      Object.values(this.props.beats.index).length - 1
-                    ].id ||
-                    this.state.hovering === this.props.beat.id ||
-                    this.state.inDropZone,
+                  this.state.hovering === this.props.beat.id || this.state.inDropZone,
                   this.props.darkMode === true
                     ? this.props.hierarchyLevel.dark
                     : this.props.hierarchyLevel.light,


### PR DESCRIPTION
# Motivation
As per discussions with Ryan, we've decided to remove this style.

It's not working visually and it also has problems in terms of correctness: the last value to come out of `Object.values` is non-deterministic so we could highlight any of the beats as the "last" added beat.