### PR TITLE
Fix the insert line control on medium horizontal timeline

### DIFF
--- a/lib/plottr_components/src/css/line_block.scss
+++ b/lib/plottr_components/src/css/line_block.scss
@@ -168,11 +168,11 @@ $medium_width: 80px;
       }
       div.template {
         font-size: 12px;
-        border-bottom: none;
+        border-top: none;
         border-right: 3px dashed $blue-8;
       }
       div.non-template {
-        border-top: none;
+        border-bottom: none;
         border-left: 3px dashed $blue-8;
       }
     }


### PR DESCRIPTION
Looks like the `none` border was the wrong way around.