### PR TITLE
Fix BeatTitle tooltips

### DIFF
--- a/lib/plottr_components/src/components/timeline/BeatTitleCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatTitleCell.js
@@ -220,23 +220,53 @@ const BeatTitleCellConnector = (connector) => {
     }
 
     renderHorizontalHoverOptions(style) {
-      const { orientation, isMedium, isSmall, beat, hierarchyLevel, hierarchyLevels, tour } =
-        this.props
+      const {
+        beatIndex,
+        beats,
+        positionOffset,
+        hierarchyEnabled,
+        isSeries,
+        orientation,
+        isMedium,
+        isSmall,
+        beat,
+        hierarchyLevel,
+        hierarchyLevels,
+        tour,
+      } = this.props
       const klasses = orientedClassName('beat-list__item__hover-options', orientation)
       const showExpandCollapse = hierarchyLevels.length - hierarchyLevel.level > 1
+      const beatTitle = beatPositionTitle(
+        beatIndex,
+        beats,
+        beat,
+        hierarchyLevels,
+        positionOffset,
+        hierarchyEnabled,
+        isSeries
+      )
       return (
         <div className={cx(klasses, { 'small-timeline': isSmall })} style={style}>
           <ButtonGroup>
             {isMedium ? null : (
-              <Button bsSize={isSmall ? 'small' : undefined} onClick={this.startEditing}>
+              <Button
+                title={`Edit ${beatTitle}`}
+                bsSize={isSmall ? 'small' : undefined}
+                onClick={this.startEditing}
+              >
                 <Glyphicon glyph="edit" />
               </Button>
             )}
-            <Button bsSize={isSmall ? 'small' : undefined} onClick={this.handleDelete}>
+            <Button
+              title={`Delete ${beatTitle}`}
+              bsSize={isSmall ? 'small' : undefined}
+              onClick={this.handleDelete}
+            >
               <Glyphicon glyph="trash" />
             </Button>
             {showExpandCollapse ? (
               <Button
+                title={`Expand/Collapse ${beatTitle}`}
                 bsSize={isSmall ? 'small' : undefined}
                 className={tour.run ? 'acts-tour-step7' : ''}
                 onClick={this.handleToggleExpanded}
@@ -269,6 +299,7 @@ const BeatTitleCellConnector = (connector) => {
 
       let button1 = (
         <Button
+          title="Insert Peer"
           className={!isFirst && tour.run ? 'acts-tour-step6' : null}
           bsSize={isSmall ? 'small' : undefined}
           block
@@ -281,6 +312,7 @@ const BeatTitleCellConnector = (connector) => {
 
       let button2 = hierarchyLevels.length - hierarchyLevel.level > 1 && (
         <Button
+          title="Insert Child"
           className={'acts-tour-step8'}
           bsSize={isSmall ? 'small' : undefined}
           block
@@ -312,13 +344,35 @@ const BeatTitleCellConnector = (connector) => {
     }
 
     renderVerticalHoverOptions(style) {
-      const { orientation, isSmall, isMedium, beat, hierarchyLevel, hierarchyLevels, tour } =
-        this.props
+      const {
+        orientation,
+        isSmall,
+        isMedium,
+        beat,
+        hierarchyLevel,
+        hierarchyLevels,
+        tour,
+        beatIndex,
+        beats,
+        positionOffset,
+        hierarchyEnabled,
+        isSeries,
+      } = this.props
+      const beatTitle = beatPositionTitle(
+        beatIndex,
+        beats,
+        beat,
+        hierarchyLevels,
+        positionOffset,
+        hierarchyEnabled,
+        isSeries
+      )
       const klasses = orientedClassName('beat-list__item__hover-options', orientation)
       const showExpandCollapse = hierarchyLevels.length - hierarchyLevel.level > 1
       return (
         <div className={cx(klasses, { 'small-timeline': isSmall })} style={style}>
           <Button
+            title={`Edit ${beatTitle}`}
             bsSize={isSmall ? 'small' : undefined}
             block
             onClick={this.startEditing}
@@ -334,11 +388,17 @@ const BeatTitleCellConnector = (connector) => {
           >
             <Glyphicon glyph="edit" />
           </Button>
-          <Button bsSize={isSmall ? 'small' : undefined} block onClick={this.handleDelete}>
+          <Button
+            title={`Delete ${beatTitle}`}
+            bsSize={isSmall ? 'small' : undefined}
+            block
+            onClick={this.handleDelete}
+          >
             <Glyphicon glyph="trash" />
           </Button>
           {showExpandCollapse && (
             <Button
+              title={`Expand/Collapse ${beatTitle}`}
               bsSize={isSmall ? 'small' : undefined}
               className={tour.run ? 'acts-tour-step7' : ''}
               onClick={this.handleToggleExpanded}
@@ -443,6 +503,15 @@ const BeatTitleCellConnector = (connector) => {
           'row-header': !isHorizontal,
           dropping: inDropZone,
         }
+        const beatTitle = beatPositionTitle(
+          beatIndex,
+          beats,
+          beat,
+          hierarchyLevels,
+          positionOffset,
+          hierarchyEnabled,
+          isSeries
+        )
         return (
           <th
             className={cx(klasses)}
@@ -455,15 +524,7 @@ const BeatTitleCellConnector = (connector) => {
             {this.renderDelete()}
             {this.renderEditInput()}
             <div
-              title={beatPositionTitle(
-                beatIndex,
-                beats,
-                beat,
-                hierarchyLevels,
-                positionOffset,
-                hierarchyEnabled,
-                isSeries
-              )}
+              title={beatTitle}
               onClick={hovering ? this.stopHovering : this.startHovering}
               draggable={!readOnly}
               onDragStart={this.handleDragStart}
@@ -478,15 +539,7 @@ const BeatTitleCellConnector = (connector) => {
           <Cell className="beat-table-cell">
             <div
               className={beatKlass}
-              title={beatPositionTitle(
-                beatIndex,
-                beats,
-                beat,
-                hierarchyLevels,
-                positionOffset,
-                hierarchyEnabled,
-                isSeries
-              )}
+              title={beatTitle}
               onMouseEnter={this.startHovering}
               onMouseLeave={this.stopHovering}
               onDrop={this.handleDrop}


### PR DESCRIPTION
Previously these tools inherited their tooltip from the beat title that made them.
So they were all "Scene 1", "Chapter 1" etc.
These tips should help our users to navigate our controls.