### PR TITLE
Keep track of migrations

### DIFF
--- a/lib/pltr/v2/reducers/file.js
+++ b/lib/pltr/v2/reducers/file.js
@@ -18,6 +18,8 @@ const file =
           loaded: true,
           dirty: action.dirty,
           version: action.version,
+          appliedMigrations: action.data.file.appliedMigrations,
+          initialVersion: action.data.file.initialVersion,
         }
 
       case FILE_SAVED:


### PR DESCRIPTION
The file loaded action discards a bunch of properties from the file key.
That includes the new attributes to keep track of the applied migrations.
The migrator will still work without those keys, but it'll harm our ability to keep track of migrations in production.