### PR TITLE
Rce normaliser test case

### DIFF
--- a/lib/plottr_components/src/components/rce/BlockButton.js
+++ b/lib/plottr_components/src/components/rce/BlockButton.js
@@ -45,13 +45,18 @@ export const handleHeadings = (editor, format) => {
 export const handleList = (editor, format) => {
   const isInList = Editor.isInList(editor, editor.selection)
 
-  Transforms.unwrapNodes(editor, {
-    match: (n) => LIST_TYPES.includes(n.type),
-    split: true,
-  })
+  // Careful!  All interactions with the editor might prompt
+  // normalisation, which could undo the operation that you're trying
+  // to implement.
+  Editor.withoutNormalizing(editor, () => {
+    Transforms.unwrapNodes(editor, {
+      match: (n) => LIST_TYPES.includes(n.type),
+      split: true,
+    })
 
-  Transforms.setNodes(editor, {
-    type: 'paragraph',
+    Transforms.setNodes(editor, {
+      type: 'paragraph',
+    })
   })
 
   // The reason we don't wrap in a list-item is because the Normalizer takes care of making sure that

--- a/lib/plottr_components/src/components/rce/MarkButton.js
+++ b/lib/plottr_components/src/components/rce/MarkButton.js
@@ -21,7 +21,7 @@ UnMemoisedMarkButton.propTypes = {
   mark: PropTypes.string.isRequired,
   icon: PropTypes.node.isRequired,
   editor: PropTypes.object.isRequired,
-  selection: PropTypes.object.isRequired,
+  selection: PropTypes.isRequired,
 }
 
 export const MarkButton = React.memo(UnMemoisedMarkButton)

--- a/lib/plottr_components/src/components/rce/Normalizer.js
+++ b/lib/plottr_components/src/components/rce/Normalizer.js
@@ -37,7 +37,7 @@ const withNormalizer = (editor) => {
       }
     }
 
-    // don't allow list-items to be children of other list-items
+    // Don't allow list-items to be children of other list-items
     if (Element.isElement(node) && node.type == 'list-item') {
       for (const [child, childPath] of Node.children(editor, path)) {
         if (Element.isElement(child) && child.type == 'list-item') {

--- a/lib/plottr_components/src/components/rce/Normalizer.js
+++ b/lib/plottr_components/src/components/rce/Normalizer.js
@@ -47,6 +47,22 @@ const withNormalizer = (editor) => {
       }
     }
 
+    // Don't allow root-level collections of nodes to all be list types.
+    if (Array.isArray(path) && path.length === 0 && node.children && node.children.length > 0) {
+      let allChildrenAreListTypes = true
+      for (const child of node.children) {
+        allChildrenAreListTypes &= Element.isElement(child) && child.type == 'list-item'
+      }
+      if (allChildrenAreListTypes) {
+        node.children = [
+          {
+            type: 'bulleted-list',
+            children: node.children,
+          },
+        ]
+      }
+    }
+
     // If a paragraph is missing the "paragraph" type, then add it.
     if (Element.isElement(node) && node.type === undefined) {
       let allChildrenAreText = true

--- a/lib/plottr_components/src/components/rce/Normalizer.js
+++ b/lib/plottr_components/src/components/rce/Normalizer.js
@@ -47,6 +47,17 @@ const withNormalizer = (editor) => {
       }
     }
 
+    // Don't allow a collection of list items to not have a parent of a list type
+    if (Element.isElement(node) && !LIST_TYPES.includes(node.type)) {
+      let allChildrenAreListTypes = true
+      for (const [child] of Node.children(editor, path)) {
+        allChildrenAreListTypes &= Element.isElement(child) && child.type == 'list-item'
+      }
+      if (allChildrenAreListTypes) {
+        Transforms.setNodes(editor, { type: 'bulleted-list' }, { at: path })
+      }
+    }
+
     // Don't allow root-level collections of nodes to all be list types.
     if (Array.isArray(path) && path.length === 0 && node.children && node.children.length > 0) {
       let allChildrenAreListTypes = true

--- a/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
+++ b/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
@@ -327,7 +327,7 @@ describe('normalize', () => {
       },
     ]
     it('should embed them into a bulleted list', () => {
-      const embeddedInBulletedList = [
+      const expectedNormalisedContent = [
         {
           type: 'bulleted-list',
           children: [
@@ -358,7 +358,74 @@ describe('normalize', () => {
           ],
         },
       ]
-      expect(normalize(topLevelListItems)).toEqual(embeddedInBulletedList)
+      expect(normalize(topLevelListItems)).toEqual(expectedNormalisedContent)
+    })
+  })
+  describe('given a collection of list-items inside another path in the tree', () => {
+    const embeddedListItems = [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                text: 'Offer clues which hint at the both the physical and',
+              },
+            ],
+          },
+          {
+            type: 'list-item',
+            children: [
+              {
+                text: 'Include clues which will point the Sleuth in the ',
+              },
+            ],
+          },
+          {
+            type: 'list-item',
+            children: [
+              {
+                text: "Do not reveal too much of the Sleuth's character, as",
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    it('should embed them into a bulleted list', () => {
+      const expectedNormalisedContent = [
+        {
+          type: 'bulleted-list',
+          children: [
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: 'Offer clues which hint at the both the physical and',
+                },
+              ],
+            },
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: 'Include clues which will point the Sleuth in the ',
+                },
+              ],
+            },
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: "Do not reveal too much of the Sleuth's character, as",
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      expect(normalize(embeddedListItems)).toEqual(expectedNormalisedContent)
     })
   })
 })

--- a/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
+++ b/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
@@ -300,3 +300,67 @@ describe('normalize', () => {
     })
   })
 })
+
+// New case
+const before = {
+  content: [
+    {
+      type: 'list-item',
+      children: [
+        {
+          text: 'Offer clues which hint at the both the physical and',
+        },
+      ],
+    },
+    {
+      type: 'list-item',
+      children: [
+        {
+          text: 'Include clues which will point the Sleuth in the ',
+        },
+      ],
+    },
+    {
+      type: 'list-item',
+      children: [
+        {
+          text: "Do not reveal too much of the Sleuth's character, as",
+        },
+      ],
+    },
+  ],
+}
+
+const after = {
+  content: [
+    {
+      type: 'bulleted-list',
+      children: [
+        {
+          type: 'list-item',
+          children: [
+            {
+              text: 'Offer clues which hint at the both the physical and',
+            },
+          ],
+        },
+        {
+          type: 'list-item',
+          children: [
+            {
+              text: 'Include clues which will point the Sleuth in the ',
+            },
+          ],
+        },
+        {
+          type: 'list-item',
+          children: [
+            {
+              text: "Do not reveal too much of the Sleuth's character, as",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
+++ b/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
@@ -299,68 +299,66 @@ describe('normalize', () => {
       expect(normalize(content)).toEqual(fixed)
     })
   })
+  describe('given a collection of top-level list-items', () => {
+    const topLevelListItems = [
+      {
+        type: 'list-item',
+        children: [
+          {
+            text: 'Offer clues which hint at the both the physical and',
+          },
+        ],
+      },
+      {
+        type: 'list-item',
+        children: [
+          {
+            text: 'Include clues which will point the Sleuth in the ',
+          },
+        ],
+      },
+      {
+        type: 'list-item',
+        children: [
+          {
+            text: "Do not reveal too much of the Sleuth's character, as",
+          },
+        ],
+      },
+    ]
+    it('should embed them into a bulleted list', () => {
+      const embeddedInBulletedList = [
+        {
+          type: 'bulleted-list',
+          children: [
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: 'Offer clues which hint at the both the physical and',
+                },
+              ],
+            },
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: 'Include clues which will point the Sleuth in the ',
+                },
+              ],
+            },
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: "Do not reveal too much of the Sleuth's character, as",
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      expect(normalize(topLevelListItems)).toEqual(embeddedInBulletedList)
+    })
+  })
 })
-
-// New case
-const before = {
-  content: [
-    {
-      type: 'list-item',
-      children: [
-        {
-          text: 'Offer clues which hint at the both the physical and',
-        },
-      ],
-    },
-    {
-      type: 'list-item',
-      children: [
-        {
-          text: 'Include clues which will point the Sleuth in the ',
-        },
-      ],
-    },
-    {
-      type: 'list-item',
-      children: [
-        {
-          text: "Do not reveal too much of the Sleuth's character, as",
-        },
-      ],
-    },
-  ],
-}
-
-const after = {
-  content: [
-    {
-      type: 'bulleted-list',
-      children: [
-        {
-          type: 'list-item',
-          children: [
-            {
-              text: 'Offer clues which hint at the both the physical and',
-            },
-          ],
-        },
-        {
-          type: 'list-item',
-          children: [
-            {
-              text: 'Include clues which will point the Sleuth in the ',
-            },
-          ],
-        },
-        {
-          type: 'list-item',
-          children: [
-            {
-              text: "Do not reveal too much of the Sleuth's character, as",
-            },
-          ],
-        },
-      ],
-    },
-  ],
-}


### PR DESCRIPTION
Sometimes we have `list-item`s that are either uncontained or contained by a non-list element type.
This PR ensures that the `list-item`s are always in valid containers.