### PR TITLE
fix missing words from lists with font style combination

### DIFF
--- a/src/common/slate_serializers/to_word.js
+++ b/src/common/slate_serializers/to_word.js
@@ -51,15 +51,18 @@ const serialize = (nodes, doc) => {
 
     switch (n.type) {
       case 'bulleted-list':
-        return children.map((li) => {
-          if (li instanceof TextRun) {
-            return new Paragraph({ children: [li], bullet: { level: 0 } })
-          } else {
-            // this isn't allowed in the UI anymore (2021.1.12) but it may still exist in the wild
-            if (li instanceof Paragraph)
-              return new Paragraph({ children: [li.root[1]], bullet: { level: 0 } })
-          }
+        return n.children.map((li) => {
+          return new Paragraph({
+            children: li.children.map(leaf),
+            bullet: { level: 0 },
+          })
         })
+      // this isn't allowed in the UI anymore (2021.1.12) but it may still exist in the wild
+      // return children.map((li) => {
+      //   if (li instanceof Paragraph)
+      //     return new Paragraph({ children: [li.root[1]], bullet: { level: 0 } })
+      // })
+      // }
       // Headings can sometimes have 1+ paragraph children, which the docx exporter does not allow
       // so we map over all the node's children (ignoring what we serialized above) and serialize
       // them again but as individual headings
@@ -87,7 +90,12 @@ const serialize = (nodes, doc) => {
         return children[0] // always an array with 1 TextRun
       case 'numbered-list':
         // make it a bullet list for now
-        return children.map((li) => new Paragraph({ children: [li], bullet: { level: 0 } }))
+        return n.children.map((li) => {
+          return new Paragraph({
+            children: li.children.map(leaf),
+            bullet: { level: 0 },
+          })
+        })
       // this isn't working for now
       // return children.map(li => new Paragraph({children: [li.root[1]], numbering: { reference: concrete, level: 0 }}))
       case 'link':


### PR DESCRIPTION
@cameronsutter @Quiescent i have no luck fixing the numbered list 😅 then i noticed there's a separate ticket for it so this fix is only for the missing words when exporting the lists to word with combination of font styles.

Ticket: https://app.ora.pm/p/320746?c=6058749
preview:
https://user-images.githubusercontent.com/19387007/129218620-ed0f0e7b-895d-4231-a7ae-8531ce60f255.mp4


