### PR TITLE
fix remove license bug

### DIFF
--- a/lib/plottr_components/src/components/dashboard/account/UserInfo.js
+++ b/lib/plottr_components/src/components/dashboard/account/UserInfo.js
@@ -2,12 +2,10 @@ import React, { useState } from 'react'
 import PropTypes from 'react-proptypes'
 import { t } from 'plottr_locales'
 import { Button } from 'react-bootstrap'
-import UnconnectedDeleteConfirmModal from '../../dialogs/DeleteConfirmModal'
+import DeleteConfirmModal from '../../dialogs/DeleteConfirmModal'
 import { checkDependencies } from '../../checkDependencies'
 
 const UserInfoConnector = (connector) => {
-  const DeleteConfirmModal = UnconnectedDeleteConfirmModal(connector)
-
   const {
     platform: { machineIdSync },
   } = connector


### PR DESCRIPTION
@Quiescent @cameronsutter no ticket for this bug, i just noticed this after i pulled the latest.
The bug can be reproduce when you click on the `Remove License` button from the Account View. 
It will throw an error it will throw an error like this 
![image](https://user-images.githubusercontent.com/19387007/134818320-b836246d-6e11-4e0e-852b-f5e9005bf222.png)

fix preview:

https://user-images.githubusercontent.com/19387007/134818353-568b67c8-afb8-4ec9-bef7-ea638a743cc9.mp4

