### PR TITLE
Remove obvious times where the `ui` was wrongly passed to component

### DIFF
--- a/lib/plottr_components/src/components/CategoryPicker.js
+++ b/lib/plottr_components/src/components/CategoryPicker.js
@@ -60,7 +60,6 @@ const CategoryPickerConnector = (connector) => {
     return connect((state, ownProps) => {
       return {
         categories: state.present.categories[ownProps.type],
-        ui: state.present.ui,
       }
     })(CategoryPicker)
   }

--- a/lib/plottr_components/src/components/project/BookList.js
+++ b/lib/plottr_components/src/components/project/BookList.js
@@ -176,7 +176,6 @@ const BookListConnector = (connector) => {
     }
 
     static propTypes = {
-      ui: PropTypes.object.isRequired,
       books: PropTypes.object.isRequired,
       lines: PropTypes.array.isRequired,
       cards: PropTypes.array.isRequired,
@@ -198,7 +197,6 @@ const BookListConnector = (connector) => {
     return connect(
       (state) => {
         return {
-          ui: state.present.ui,
           books: state.present.books,
           lines: state.present.lines,
           cards: state.present.cards,

--- a/lib/plottr_components/src/components/project/BookSelectList.js
+++ b/lib/plottr_components/src/components/project/BookSelectList.js
@@ -113,7 +113,6 @@ const BookSelectListConnector = (connector) => {
       remove: PropTypes.func.isRequired,
       selectedBooks: PropTypes.array.isRequired,
       books: PropTypes.object.isRequired,
-      ui: PropTypes.object.isRequired,
     }
   }
 
@@ -125,7 +124,6 @@ const BookSelectListConnector = (connector) => {
 
     return connect((state) => {
       return {
-        ui: state.present.ui,
         books: state.present.books,
         series: state.present.series,
       }

--- a/lib/plottr_components/src/components/project/EditSeries.js
+++ b/lib/plottr_components/src/components/project/EditSeries.js
@@ -130,7 +130,6 @@ const EditSeriesConnector = (connector) => {
   }
 
   EditSeries.propTypes = {
-    ui: PropTypes.object.isRequired,
     series: PropTypes.object.isRequired,
     actions: PropTypes.object.isRequired,
   }
@@ -148,7 +147,6 @@ const EditSeriesConnector = (connector) => {
     return connect(
       (state) => {
         return {
-          ui: state.present.ui,
           series: state.present.series,
         }
       },


### PR DESCRIPTION
# Motivation

Whenever a component depends on the entire `ui` key, there's a good chance that it'll be re-rendered unnecessarily.
Curiously, the only places that were still doing this didn't even use the object(!)