### PR TITLE
Nested bullet points

### DIFF
--- a/lib/plottr_components/src/components/rce/BlockButton.js
+++ b/lib/plottr_components/src/components/rce/BlockButton.js
@@ -48,7 +48,7 @@ export const handleHeadings = (editor, format, logger) => {
   Transforms.wrapNodes(editor, { type: format })
 }
 
-export const handleList = (editor, format, logger) => {
+export const handleList = (editor, format, logger, force = false) => {
   try {
     const isInList = Editor.isInList(editor, editor.selection)
 
@@ -68,7 +68,7 @@ export const handleList = (editor, format, logger) => {
 
     // The reason we don't wrap in a list-item is because the Normalizer takes care of making sure that
     // list-items are the only children of lists. If we try to do it in here we get a double bullet effect
-    if (!isInList) {
+    if (!isInList || force) {
       const block = { type: format, children: [] }
       Transforms.wrapNodes(editor, block)
 

--- a/lib/plottr_components/src/components/rce/BlockButton.js
+++ b/lib/plottr_components/src/components/rce/BlockButton.js
@@ -48,7 +48,7 @@ export const handleHeadings = (editor, format, logger) => {
   Transforms.wrapNodes(editor, { type: format })
 }
 
-export const handleList = (editor, format, logger) => {
+export const handleList = (editor, inputFormat, logger) => {
   try {
     const isInList = Editor.isInList(editor, editor.selection)
 
@@ -56,6 +56,7 @@ export const handleList = (editor, format, logger) => {
       const [parentElement, parentPath] = Editor.parentOfType(editor, editor.selection, {
         match: (n) => LIST_TYPES.includes(n.type),
       })
+      const format = inputFormat || parentElement.type
       if (parentElement.type !== format) {
         Transforms.setNodes(
           editor,
@@ -87,6 +88,7 @@ export const handleList = (editor, format, logger) => {
     // The reason we don't wrap in a list-item is because the Normalizer takes care of making sure that
     // list-items are the only children of lists. If we try to do it in here we get a double bullet effect
     if (!isInList) {
+      const format = inputFormat
       const block = { type: format, children: [] }
       Transforms.wrapNodes(editor, block)
 

--- a/lib/plottr_components/src/components/rce/BlockButton.js
+++ b/lib/plottr_components/src/components/rce/BlockButton.js
@@ -48,7 +48,7 @@ export const handleHeadings = (editor, format, logger) => {
   Transforms.wrapNodes(editor, { type: format })
 }
 
-export const handleList = (editor, format, logger, force = false) => {
+export const handleList = (editor, format, logger) => {
   try {
     const isInList = Editor.isInList(editor, editor.selection)
 
@@ -68,7 +68,7 @@ export const handleList = (editor, format, logger, force = false) => {
 
     // The reason we don't wrap in a list-item is because the Normalizer takes care of making sure that
     // list-items are the only children of lists. If we try to do it in here we get a double bullet effect
-    if (!isInList || force) {
+    if (!isInList) {
       const block = { type: format, children: [] }
       Transforms.wrapNodes(editor, block)
 

--- a/lib/plottr_components/src/components/rce/BlockButton.js
+++ b/lib/plottr_components/src/components/rce/BlockButton.js
@@ -52,6 +52,24 @@ export const handleList = (editor, format, logger) => {
   try {
     const isInList = Editor.isInList(editor, editor.selection)
 
+    if (isInList) {
+      const [parentElement, parentPath] = Editor.parentOfType(editor, editor.selection, {
+        match: (n) => LIST_TYPES.includes(n.type),
+      })
+      if (parentElement.type !== format) {
+        Transforms.setNodes(
+          editor,
+          {
+            type: format,
+          },
+          {
+            at: parentPath,
+          }
+        )
+        return
+      }
+    }
+
     // Careful!  All interactions with the editor might prompt
     // normalisation, which could undo the operation that you're trying
     // to implement.

--- a/lib/plottr_components/src/components/rce/DedentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/DedentParagraphButton.js
@@ -1,12 +1,32 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
 import { FaOutdent } from 'react-icons/fa'
 
 import Button from '../Button'
+import { isBlockActive } from './BlockButton'
 
-const DedentParagraphButton = () => {
+const DedentParagraphButton = ({ editor, logger }) => {
+  const [blockIsActive, setBlockIsActive] = useState(false)
+
+  useEffect(() => {
+    const timeout = setInterval(() => {
+      const numberListIsActive = isBlockActive(editor, 'numbered-list', logger)
+      const bulletListIsActive = isBlockActive(editor, 'bulleted-list', logger)
+      const newBlockIsActive = numberListIsActive || bulletListIsActive
+      if (newBlockIsActive !== blockIsActive) {
+        setBlockIsActive(newBlockIsActive)
+      }
+    }, 100)
+
+    return () => {
+      clearInterval(timeout)
+    }
+  }, [setBlockIsActive, blockIsActive, editor.selection, logger])
+
   return (
     <Button
-      bsStyle="default"
+      bsStyle={cx('default', { disabled: !blockIsActive })}
       onMouseDown={(event) => {
         event.preventDefault()
       }}
@@ -14,6 +34,11 @@ const DedentParagraphButton = () => {
       <FaOutdent />
     </Button>
   )
+}
+
+DedentParagraphButton.propTypes = {
+  editor: PropTypes.object.isRequired,
+  logger: PropTypes.object.isRequired,
 }
 
 export default DedentParagraphButton

--- a/lib/plottr_components/src/components/rce/DedentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/DedentParagraphButton.js
@@ -1,36 +1,50 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { FaOutdent } from 'react-icons/fa'
 
 import Button from '../Button'
-import { isBlockActive } from './BlockButton'
+import { isBlockActive, handleList } from './BlockButton'
 
 const DedentParagraphButton = ({ editor, logger }) => {
+  const [listType, setListType] = useState(false)
   const [blockIsActive, setBlockIsActive] = useState(false)
 
   useEffect(() => {
     const timeout = setInterval(() => {
       const numberListIsActive = isBlockActive(editor, 'numbered-list', logger)
       const bulletListIsActive = isBlockActive(editor, 'bulleted-list', logger)
+
       const newBlockIsActive = numberListIsActive || bulletListIsActive
       if (newBlockIsActive !== blockIsActive) {
         setBlockIsActive(newBlockIsActive)
+      }
+
+      const newListType = numberListIsActive
+        ? 'numbered-list'
+        : bulletListIsActive
+        ? 'bulleted-list'
+        : null
+      if (newListType !== listType) {
+        setListType(newListType)
       }
     }, 100)
 
     return () => {
       clearInterval(timeout)
     }
-  }, [setBlockIsActive, blockIsActive, editor.selection, logger])
+  }, [setListType, listType, setBlockIsActive, blockIsActive, editor.selection, logger])
+
+  const handleClick = useCallback(
+    (event) => {
+      event.preventDefault()
+      handleList(editor, listType, logger, true)
+    },
+    [editor, logger, listType]
+  )
 
   return (
-    <Button
-      bsStyle={cx('default', { disabled: !blockIsActive })}
-      onMouseDown={(event) => {
-        event.preventDefault()
-      }}
-    >
+    <Button bsStyle={cx('default', { disabled: !blockIsActive })} onMouseDown={handleClick}>
       <FaOutdent />
     </Button>
   )

--- a/lib/plottr_components/src/components/rce/DedentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/DedentParagraphButton.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { FaOutdent } from 'react-icons/fa'
+
+import Button from '../Button'
+
+const DedentParagraphButton = () => {
+  return (
+    <Button
+      bsStyle="default"
+      onMouseDown={(event) => {
+        event.preventDefault()
+      }}
+    >
+      <FaOutdent />
+    </Button>
+  )
+}
+
+export default DedentParagraphButton

--- a/lib/plottr_components/src/components/rce/IndentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/IndentParagraphButton.js
@@ -14,7 +14,29 @@ const indent = (editor, listType, logger) => {
   const [, parentPath] = Editor.parentOfType(editor, editor.selection, {
     match: (_) => true,
   })
-  const previousElement = Editor.previousSibling(editor, parentPath)
+  const hit = Editor.previousSibling(editor, parentPath)
+  // If the previous element was a list already, then just move this
+  // node into it at the end.
+  if (hit) {
+    const [previousElement, previousElementPath] = hit
+    if (previousElement.type === listType) {
+      Transforms.moveNodes(editor, {
+        at: parentPath,
+        to: [...previousElementPath, previousElement.children.length],
+      })
+      // If moving the node means that we have two lists abutting each
+      // other, merge them.  (Note that normalisation will happen
+      // between the previous step and this one to remove empty lists.)
+      const hit = Editor.next(editor, { at: previousElementPath })
+      if (hit) {
+        const [nextSibling, nextSiblingPath] = hit
+        if (nextSibling.type === listType) {
+          Transforms.mergeNodes(editor, { at: nextSiblingPath })
+        }
+      }
+      return
+    }
+  }
 
   Editor.withoutNormalizing(editor, () => {
     const block = { type: listType, children: [] }

--- a/lib/plottr_components/src/components/rce/IndentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/IndentParagraphButton.js
@@ -2,9 +2,26 @@ import React, { useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { FaIndent } from 'react-icons/fa'
+import { Transforms, Editor } from 'slate'
 
 import Button from '../Button'
-import { handleList, isBlockActive } from './BlockButton'
+import { isBlockActive } from './BlockButton'
+
+const indent = (editor, listType, logger) => {
+  const isInList = Editor.isInList(editor, editor.selection)
+  if (!isInList) return
+
+  const [, parentPath] = Editor.parentOfType(editor, editor.selection, {
+    match: (_) => true,
+  })
+  const previousElement = Editor.previousSibling(editor, parentPath)
+
+  Editor.withoutNormalizing(editor, () => {
+    const block = { type: listType, children: [] }
+    Transforms.wrapNodes(editor, block, { at: parentPath })
+  })
+  Editor.normalize(editor)
+}
 
 const IndentParagraphButton = ({ editor, logger }) => {
   const [listType, setListType] = useState(false)
@@ -38,7 +55,7 @@ const IndentParagraphButton = ({ editor, logger }) => {
   const handleClick = useCallback(
     (event) => {
       event.preventDefault()
-      handleList(editor, listType, logger, true)
+      indent(editor, listType, logger)
     },
     [editor, logger, listType]
   )

--- a/lib/plottr_components/src/components/rce/IndentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/IndentParagraphButton.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { FaIndent } from 'react-icons/fa'
+
+import Button from '../Button'
+
+const IndentParagraphButton = () => {
+  return (
+    <Button
+      bsStyle="default"
+      onMouseDown={(event) => {
+        event.preventDefault()
+      }}
+    >
+      <FaIndent />
+    </Button>
+  )
+}
+
+export default IndentParagraphButton

--- a/lib/plottr_components/src/components/rce/IndentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/IndentParagraphButton.js
@@ -7,13 +7,24 @@ import { Transforms, Editor } from 'slate'
 import Button from '../Button'
 import { isBlockActive } from './BlockButton'
 
-const indent = (editor, listType, logger) => {
+const parentElementType = (editor, path) => {
+  const hit = Editor.parent(editor, path)
+  if (hit) {
+    const [parentElement] = hit
+    return parentElement.type
+  }
+
+  return null
+}
+
+export const indent = (editor, inputListType, logger) => {
   const isInList = Editor.isInList(editor, editor.selection)
-  if (!isInList) return
+  if (!isInList) return false
 
   const [, parentPath] = Editor.parentOfType(editor, editor.selection, {
     match: (_) => true,
   })
+  const listType = inputListType || parentElementType(editor, parentPath)
   const hit = Editor.previousSibling(editor, parentPath)
   // If the previous element was a list already, then just move this
   // node into it at the end.
@@ -34,7 +45,7 @@ const indent = (editor, listType, logger) => {
           Transforms.mergeNodes(editor, { at: nextSiblingPath })
         }
       }
-      return
+      return true
     }
   }
 
@@ -43,6 +54,7 @@ const indent = (editor, listType, logger) => {
     Transforms.wrapNodes(editor, block, { at: parentPath })
   })
   Editor.normalize(editor)
+  return true
 }
 
 const IndentParagraphButton = ({ editor, logger }) => {

--- a/lib/plottr_components/src/components/rce/IndentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/IndentParagraphButton.js
@@ -1,37 +1,50 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { FaIndent } from 'react-icons/fa'
 
 import Button from '../Button'
-import { isBlockActive } from './BlockButton'
+import { handleList, isBlockActive } from './BlockButton'
 
 const IndentParagraphButton = ({ editor, logger }) => {
+  const [listType, setListType] = useState(false)
   const [blockIsActive, setBlockIsActive] = useState(false)
 
   useEffect(() => {
     const timeout = setInterval(() => {
       const numberListIsActive = isBlockActive(editor, 'numbered-list', logger)
       const bulletListIsActive = isBlockActive(editor, 'bulleted-list', logger)
+
       const newBlockIsActive = numberListIsActive || bulletListIsActive
       if (newBlockIsActive !== blockIsActive) {
         setBlockIsActive(newBlockIsActive)
+      }
+
+      const newListType = numberListIsActive
+        ? 'numbered-list'
+        : bulletListIsActive
+        ? 'bulleted-list'
+        : null
+      if (newListType !== listType) {
+        setListType(newListType)
       }
     }, 100)
 
     return () => {
       clearInterval(timeout)
     }
-  }, [setBlockIsActive, blockIsActive, editor.selection, logger])
+  }, [setListType, listType, setBlockIsActive, blockIsActive, editor.selection, logger])
+
+  const handleClick = useCallback(
+    (event) => {
+      event.preventDefault()
+      handleList(editor, listType, logger, true)
+    },
+    [editor, logger, listType]
+  )
 
   return (
-    <Button
-      bsStyle={cx('default', { disabled: !blockIsActive })}
-      onMouseDown={(event) => {
-        event.preventDefault()
-        if (!blockIsActive) return
-      }}
-    >
+    <Button bsStyle={cx('default', { disabled: !blockIsActive })} onMouseDown={handleClick}>
       <FaIndent />
     </Button>
   )

--- a/lib/plottr_components/src/components/rce/IndentParagraphButton.js
+++ b/lib/plottr_components/src/components/rce/IndentParagraphButton.js
@@ -1,19 +1,45 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
 import { FaIndent } from 'react-icons/fa'
 
 import Button from '../Button'
+import { isBlockActive } from './BlockButton'
 
-const IndentParagraphButton = () => {
+const IndentParagraphButton = ({ editor, logger }) => {
+  const [blockIsActive, setBlockIsActive] = useState(false)
+
+  useEffect(() => {
+    const timeout = setInterval(() => {
+      const numberListIsActive = isBlockActive(editor, 'numbered-list', logger)
+      const bulletListIsActive = isBlockActive(editor, 'bulleted-list', logger)
+      const newBlockIsActive = numberListIsActive || bulletListIsActive
+      if (newBlockIsActive !== blockIsActive) {
+        setBlockIsActive(newBlockIsActive)
+      }
+    }, 100)
+
+    return () => {
+      clearInterval(timeout)
+    }
+  }, [setBlockIsActive, blockIsActive, editor.selection, logger])
+
   return (
     <Button
-      bsStyle="default"
+      bsStyle={cx('default', { disabled: !blockIsActive })}
       onMouseDown={(event) => {
         event.preventDefault()
+        if (!blockIsActive) return
       }}
     >
       <FaIndent />
     </Button>
   )
+}
+
+IndentParagraphButton.propTypes = {
+  editor: PropTypes.object.isRequired,
+  logger: PropTypes.object.isRequired,
 }
 
 export default IndentParagraphButton

--- a/lib/plottr_components/src/components/rce/Normalizer.js
+++ b/lib/plottr_components/src/components/rce/Normalizer.js
@@ -27,10 +27,13 @@ const withNormalizer = (editor) => {
       }
     }
 
-    // Only allow list-items as children of lists
+    // Only allow list-items and list types as children of lists
     if (Element.isElement(node) && LIST_TYPES.includes(node.type)) {
       for (const [child, childPath] of Node.children(editor, path)) {
-        if (Element.isElement(child) && child.type != 'list-item') {
+        if (
+          Element.isElement(child) &&
+          !(child.type === 'list-item' || LIST_TYPES.includes(child.type))
+        ) {
           Transforms.setNodes(editor, { type: 'list-item' }, { at: childPath })
           return
         }

--- a/lib/plottr_components/src/components/rce/RichTextEditor.js
+++ b/lib/plottr_components/src/components/rce/RichTextEditor.js
@@ -3,7 +3,7 @@ import PropTypes from 'react-proptypes'
 import cx from 'classnames'
 import { t } from 'plottr_locales'
 import isHotkey from 'is-hotkey'
-import { Transforms } from 'slate'
+import { Editor, Transforms } from 'slate'
 import { Slate, Editable, ReactEditor } from 'slate-react'
 import UnconnectedToolBar from './ToolBar'
 import { toggleMark } from './MarkButton'
@@ -14,6 +14,8 @@ import { useRegisterEditor } from './editor-registry'
 import { useEditState } from './useEditState'
 
 import { checkDependencies } from '../checkDependencies'
+import { indent } from '../../../dist/components/rce/IndentParagraphButton'
+import { handleList } from '../../../dist/components/rce/BlockButton'
 
 const HOTKEYS = {
   'mod+b': 'bold',
@@ -120,6 +122,20 @@ const RichTextEditorConnector = (connector) => {
     )
 
     const handleKeyDown = (event) => {
+      if (event.key === 'Tab') {
+        if (event.shiftKey) {
+          if (Editor.isInList(editor, editor.selection)) {
+            handleList(editor, null, log)
+            event.preventDefault()
+            event.stopPropagation()
+            return
+          }
+        } else if (indent(editor, null, log)) {
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+      }
       for (const hotkey in HOTKEYS) {
         if (isHotkey(hotkey, event)) {
           event.preventDefault()

--- a/lib/plottr_components/src/components/rce/RichTextEditor.js
+++ b/lib/plottr_components/src/components/rce/RichTextEditor.js
@@ -14,8 +14,8 @@ import { useRegisterEditor } from './editor-registry'
 import { useEditState } from './useEditState'
 
 import { checkDependencies } from '../checkDependencies'
-import { indent } from '../../../dist/components/rce/IndentParagraphButton'
-import { handleList } from '../../../dist/components/rce/BlockButton'
+import { indent } from './IndentParagraphButton'
+import { handleList } from './BlockButton'
 
 const HOTKEYS = {
   'mod+b': 'bold',

--- a/lib/plottr_components/src/components/rce/ToolBar.js
+++ b/lib/plottr_components/src/components/rce/ToolBar.js
@@ -107,8 +107,8 @@ const UnconnectedToolBar = (connector) => {
             <BlockButton format="block-quote" icon={<FaQuoteLeft />} editor={editor} logger={log} />
             <BlockButton format="numbered-list" icon={<FaListOl />} editor={editor} logger={log} />
             <BlockButton format="bulleted-list" icon={<FaListUl />} editor={editor} logger={log} />
-            <IndentParagraphButton />
-            <DedentParagraphButton />
+            <IndentParagraphButton editor={editor} logger={log} />
+            <DedentParagraphButton editor={editor} logger={log} />
             <LinkButton editor={editor} logger={log} />
             <ImagesButton editor={editor} />
           </ButtonGroup>

--- a/lib/plottr_components/src/components/rce/ToolBar.js
+++ b/lib/plottr_components/src/components/rce/ToolBar.js
@@ -16,6 +16,8 @@ import { t } from 'plottr_locales'
 import ButtonGroup from '../ButtonGroup'
 import ButtonToolbar from '../ButtonToolbar'
 import UnconnectedFloater from '../PlottrFloater'
+import IndentParagraphButton from './IndentParagraphButton'
+import DedentParagraphButton from './DedentParagraphButton'
 import { addColorMark } from './ColorButton'
 import UnconnectedImagesButton from './ImagesButton'
 import { MarkButton } from './MarkButton'
@@ -105,6 +107,8 @@ const UnconnectedToolBar = (connector) => {
             <BlockButton format="block-quote" icon={<FaQuoteLeft />} editor={editor} logger={log} />
             <BlockButton format="numbered-list" icon={<FaListOl />} editor={editor} logger={log} />
             <BlockButton format="bulleted-list" icon={<FaListUl />} editor={editor} logger={log} />
+            <IndentParagraphButton />
+            <DedentParagraphButton />
             <LinkButton editor={editor} logger={log} />
             <ImagesButton editor={editor} />
           </ButtonGroup>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plottr",
-  "version": "2022.6.29-alpha.5",
+  "version": "2022.6.29-alpha.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "plottr",
-      "version": "2022.6.29-alpha.5",
+      "version": "2022.6.29-alpha.7",
       "dependencies": {
         "@electron/remote": "^2.0.1",
         "axios": "^0.22.0",
@@ -277,6 +277,18 @@
         "tiny-warning": "^1.0.3"
       }
     },
+    "lib/plottr_components/node_modules/slate-history": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.66.0.tgz",
+      "integrity": "sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^5.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.65.3"
+      }
+    },
     "lib/plottr_components/node_modules/slate-hyperscript": {
       "version": "0.77.0",
       "dev": true,
@@ -287,6 +299,33 @@
       "peerDependencies": {
         "slate": ">=0.65.3"
       }
+    },
+    "lib/plottr_components/node_modules/slate-react": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.80.0.tgz",
+      "integrity": "sha512-aZJ5MFf7OrSOcMkDG6V9lu3ZzjC0jZ7xAA1kqXPVYtL3XBVu0YQ8MVm4Mx/xQTc1sdqe1Bx/kdkT8Pz6KyaWEQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/is-hotkey": "^0.1.1",
+        "@types/lodash": "^4.14.149",
+        "direction": "^1.0.3",
+        "is-hotkey": "^0.1.6",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.4",
+        "scroll-into-view-if-needed": "^2.2.20",
+        "tiny-invariant": "1.0.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "slate": ">=0.65.3"
+      }
+    },
+    "lib/plottr_components/node_modules/tiny-invariant": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
+      "dev": true
     },
     "lib/plottr_firebase": {
       "version": "1.0.0",
@@ -368,6 +407,42 @@
       "version": "9.0.12",
       "dev": true,
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "lib/pltr/node_modules/slate": {
+      "version": "0.65.3",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.65.3.tgz",
+      "integrity": "sha512-n8wa2MKyWhCMRyVkXuMf67MmOYSeoHnqS1qYivor+/y0puNvQgXDUjC7TJJqUjhVqJ6zg2IeuYd0WfSYdAJs4g==",
+      "dev": true,
+      "dependencies": {
+        "@types/esrever": "^0.2.0",
+        "esrever": "^0.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "immer": "^8.0.1",
+        "is-plain-object": "^3.0.0",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "lib/pltr/node_modules/slate-hyperscript": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/slate-hyperscript/-/slate-hyperscript-0.62.0.tgz",
+      "integrity": "sha512-PbtxrrIr4qPvtPmKli4/FnvQFjf8zmnF0kyNeDQGHvUzpHnsoSYHM/i4POye3/qt5d8WGukiJBPL03QsIW+SIw==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^3.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.55.0"
+      }
+    },
+    "lib/pltr/node_modules/slate/node_modules/immer": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
+      "integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -4153,8 +4228,9 @@
     },
     "node_modules/@types/esrever": {
       "version": "0.2.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/esrever/-/esrever-0.2.1.tgz",
+      "integrity": "sha512-vRLFhQxGVkyUF7opxv66MQHoRSOBkbbitj1OGd6My4XR6HwCorUZxSiJejF3s4OxmEFTjfRRGwm6GUhuQETP6Q==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "0.0.51",
@@ -4235,8 +4311,9 @@
     },
     "node_modules/@types/is-hotkey": {
       "version": "0.1.7",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.7.tgz",
+      "integrity": "sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -4273,8 +4350,9 @@
     },
     "node_modules/@types/lodash": {
       "version": "4.14.182",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "dev": true
     },
     "node_modules/@types/long": {
       "version": "4.0.1",
@@ -7361,8 +7439,9 @@
     },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.17",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -8400,8 +8479,9 @@
     },
     "node_modules/direction": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "direction": "cli.js"
       },
@@ -13209,20 +13289,6 @@
     },
     "node_modules/immediate": {
       "version": "3.0.6",
-      "license": "MIT"
-    },
-    "node_modules/immer": {
-      "version": "8.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/immutable": {
-      "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -20869,6 +20935,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/sass/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "dev": true
+    },
     "node_modules/sax": {
       "version": "1.2.4",
       "license": "ISC"
@@ -20914,8 +20986,9 @@
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
+      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^1.0.17"
       }
@@ -21267,82 +21340,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/slate": {
-      "version": "0.65.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/esrever": "^0.2.0",
-        "esrever": "^0.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "immer": "^8.0.1",
-        "is-plain-object": "^3.0.0",
-        "tiny-warning": "^1.0.3"
-      }
-    },
-    "node_modules/slate-history": {
-      "version": "0.66.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^5.0.0"
-      },
-      "peerDependencies": {
-        "slate": ">=0.65.3"
-      }
-    },
-    "node_modules/slate-history/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/slate-hyperscript": {
-      "version": "0.62.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^3.0.0"
-      },
-      "peerDependencies": {
-        "slate": ">=0.55.0"
-      }
-    },
-    "node_modules/slate-react": {
-      "version": "0.80.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/is-hotkey": "^0.1.1",
-        "@types/lodash": "^4.14.149",
-        "direction": "^1.0.3",
-        "is-hotkey": "^0.1.6",
-        "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.4",
-        "scroll-into-view-if-needed": "^2.2.20",
-        "tiny-invariant": "1.0.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.65.3"
-      }
-    },
-    "node_modules/slate-react/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/slate-react/node_modules/tiny-invariant": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
@@ -27724,6 +27721,8 @@
     },
     "@types/esrever": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/esrever/-/esrever-0.2.1.tgz",
+      "integrity": "sha512-vRLFhQxGVkyUF7opxv66MQHoRSOBkbbitj1OGd6My4XR6HwCorUZxSiJejF3s4OxmEFTjfRRGwm6GUhuQETP6Q==",
       "dev": true
     },
     "@types/estree": {
@@ -27796,6 +27795,8 @@
     },
     "@types/is-hotkey": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.7.tgz",
+      "integrity": "sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
@@ -27828,6 +27829,8 @@
     },
     "@types/lodash": {
       "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
       "dev": true
     },
     "@types/long": {
@@ -29945,6 +29948,8 @@
     },
     "compute-scroll-into-view": {
       "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
       "dev": true
     },
     "concat-map": {
@@ -30620,6 +30625,8 @@
     },
     "direction": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
       "dev": true
     },
     "discontinuous-range": {
@@ -33893,14 +33900,6 @@
     },
     "immediate": {
       "version": "3.0.6"
-    },
-    "immer": {
-      "version": "8.0.4",
-      "dev": true
-    },
-    "immutable": {
-      "version": "4.0.0",
-      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -37507,12 +37506,43 @@
             "tiny-warning": "^1.0.3"
           }
         },
+        "slate-history": {
+          "version": "0.66.0",
+          "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.66.0.tgz",
+          "integrity": "sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^5.0.0"
+          }
+        },
         "slate-hyperscript": {
           "version": "0.77.0",
           "dev": true,
           "requires": {
             "is-plain-object": "^5.0.0"
           }
+        },
+        "slate-react": {
+          "version": "0.80.0",
+          "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.80.0.tgz",
+          "integrity": "sha512-aZJ5MFf7OrSOcMkDG6V9lu3ZzjC0jZ7xAA1kqXPVYtL3XBVu0YQ8MVm4Mx/xQTc1sdqe1Bx/kdkT8Pz6KyaWEQ==",
+          "dev": true,
+          "requires": {
+            "@types/is-hotkey": "^0.1.1",
+            "@types/lodash": "^4.14.149",
+            "direction": "^1.0.3",
+            "is-hotkey": "^0.1.6",
+            "is-plain-object": "^5.0.0",
+            "lodash": "^4.17.4",
+            "scroll-into-view-if-needed": "^2.2.20",
+            "tiny-invariant": "1.0.6"
+          }
+        },
+        "tiny-invariant": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+          "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
+          "dev": true
         }
       }
     },
@@ -37582,6 +37612,37 @@
         "immer": {
           "version": "9.0.12",
           "dev": true
+        },
+        "slate": {
+          "version": "0.65.3",
+          "resolved": "https://registry.npmjs.org/slate/-/slate-0.65.3.tgz",
+          "integrity": "sha512-n8wa2MKyWhCMRyVkXuMf67MmOYSeoHnqS1qYivor+/y0puNvQgXDUjC7TJJqUjhVqJ6zg2IeuYd0WfSYdAJs4g==",
+          "dev": true,
+          "requires": {
+            "@types/esrever": "^0.2.0",
+            "esrever": "^0.2.0",
+            "fast-deep-equal": "^3.1.3",
+            "immer": "^8.0.1",
+            "is-plain-object": "^3.0.0",
+            "tiny-warning": "^1.0.3"
+          },
+          "dependencies": {
+            "immer": {
+              "version": "8.0.4",
+              "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
+              "integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==",
+              "dev": true
+            }
+          }
+        },
+        "slate-hyperscript": {
+          "version": "0.62.0",
+          "resolved": "https://registry.npmjs.org/slate-hyperscript/-/slate-hyperscript-0.62.0.tgz",
+          "integrity": "sha512-PbtxrrIr4qPvtPmKli4/FnvQFjf8zmnF0kyNeDQGHvUzpHnsoSYHM/i4POye3/qt5d8WGukiJBPL03QsIW+SIw==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^3.0.0"
+          }
         }
       }
     },
@@ -39171,6 +39232,14 @@
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
         "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "dependencies": {
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+          "dev": true
+        }
       }
     },
     "sass-loader": {
@@ -39225,6 +39294,8 @@
     },
     "scroll-into-view-if-needed": {
       "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
+      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
       "dev": true,
       "requires": {
         "compute-scroll-into-view": "^1.0.17"
@@ -39475,62 +39546,6 @@
     "slash": {
       "version": "2.0.0",
       "dev": true
-    },
-    "slate": {
-      "version": "0.65.3",
-      "dev": true,
-      "requires": {
-        "@types/esrever": "^0.2.0",
-        "esrever": "^0.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "immer": "^8.0.1",
-        "is-plain-object": "^3.0.0",
-        "tiny-warning": "^1.0.3"
-      }
-    },
-    "slate-history": {
-      "version": "0.66.0",
-      "dev": true,
-      "requires": {
-        "is-plain-object": "^5.0.0"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "5.0.0",
-          "dev": true
-        }
-      }
-    },
-    "slate-hyperscript": {
-      "version": "0.62.0",
-      "dev": true,
-      "requires": {
-        "is-plain-object": "^3.0.0"
-      }
-    },
-    "slate-react": {
-      "version": "0.80.0",
-      "dev": true,
-      "requires": {
-        "@types/is-hotkey": "^0.1.1",
-        "@types/lodash": "^4.14.149",
-        "direction": "^1.0.3",
-        "is-hotkey": "^0.1.6",
-        "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.4",
-        "scroll-into-view-if-needed": "^2.2.20",
-        "tiny-invariant": "1.0.6"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "tiny-invariant": {
-          "version": "1.0.6",
-          "dev": true
-        }
-      }
     },
     "slice-ansi": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "validate": "npm-run-all format:check lint test",
     "import-test": "npm run test:aCoronersTale && npm run test:fractureTest && npm run test:theTurn && npm run test:import-scrivener",
     "test:import-scrivener": "jest test/end-to-end/import-scrivener.test.js",
-    "test:aCoronersTale": "electron --inspect=5858 . --import-from-scrivener ./examples/A-Coroners-Tale-Temp2.scriv --output-file ./examples/test_output/A-Coroners-Tale-Temp2.pltr" ,
+    "test:aCoronersTale": "electron --inspect=5858 . --import-from-scrivener ./examples/A-Coroners-Tale-Temp2.scriv --output-file ./examples/test_output/A-Coroners-Tale-Temp2.pltr",
     "test:fractureTest": "electron --inspect=5858 . --import-from-scrivener ./examples/Fractured-Test-Import-to-Plottr.scriv --output-file ./examples/test_output/Fractured-Test-Import-to-Plottr.pltr",
-    "test:theTurn": "electron --inspect=5858 . --import-from-scrivener ./examples/The-Turn.scriv --output-file ./examples/test_output/The-Turn.pltr" 
+    "test:theTurn": "electron --inspect=5858 . --import-from-scrivener ./examples/The-Turn.scriv --output-file ./examples/test_output/The-Turn.pltr"
   },
   "dependencies": {
     "@electron/remote": "^2.0.1",


### PR DESCRIPTION
# Motivation
Bullet lists and numbered lists are only available on the root-level.
Our users would like them to be available at indented levels.

# Approach
This PR enables list items to have bullet/numbered lists as children.
It adds two buttons to the RCE toolbar to indent and decent a numbered section; the indentation controls are disabled when the cursor isn't in a list of some kind.
This PR also binds `tab` and `shift+tab` to indent and dedent respectively to mimic similar hotkeys in other editors.


https://user-images.githubusercontent.com/1457336/173395972-ec99249e-86ec-4126-8b93-d540ecb573be.mp4

