### PR TITLE
Normaliser dont allow images last

### DIFF
--- a/lib/plottr_components/src/components/rce/Normalizer.js
+++ b/lib/plottr_components/src/components/rce/Normalizer.js
@@ -1,5 +1,5 @@
 import { Editor, Transforms, Element, Node } from 'slate'
-import { LIST_TYPES, HEADING_TYPES, createEditor } from './helpers'
+import { LIST_TYPES, HEADING_TYPES, IMAGE_TYPES, createEditor } from './helpers'
 
 const withNormalizer = (editor) => {
   const { normalizeNode } = editor
@@ -95,6 +95,35 @@ const withNormalizer = (editor) => {
       if (allChildrenAreText) {
         Transforms.setNodes(editor, { type: 'paragraph' }, { at: path })
         return
+      }
+    }
+
+    // Ensure that there's always something (by default a paragraph)
+    // after an image at the end of a document.
+    if (Element.isElement(node) && IMAGE_TYPES.includes(node.type)) {
+      const parent = Editor.parent(editor, path)
+      // If we don't have a parent for an image then something's gone
+      // horribly wrong(!)
+      if (parent) {
+        const [parentNode, parentPath] = parent
+        // If this image is in the root's children, check whether it's
+        // the last element
+        if (
+          parentPath.length === 0 &&
+          parentNode.children.indexOf(node) === parentNode.children.length - 1
+        ) {
+          const emptyParagraph = {
+            type: 'paragraph',
+            children: [
+              {
+                text: '',
+              },
+            ],
+          }
+          Transforms.insertNodes(editor, emptyParagraph, { at: [parentNode.children.length] })
+        }
+      } else {
+        console.warn("Silent invariant violated.  Image doesn't have a parent!")
       }
     }
 

--- a/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
+++ b/lib/plottr_components/src/components/rce/__tests__/Normalizer.test.js
@@ -483,4 +483,97 @@ describe('normalize', () => {
       expect(normalize(dummyLog)(exampleFromWild)).toEqual(exampleFromWildFixed)
     })
   })
+  describe('given a document where the last root element is an image', () => {
+    const exampleFromWild = [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: 'A paragraph',
+          },
+        ],
+      },
+      {
+        type: 'numbered-list',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                text: 'a numbered item,',
+              },
+            ],
+          },
+          {
+            type: 'list-item',
+            children: [
+              {
+                text: 'another.',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'image-data',
+        data: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABALDA4MChAODQ4SERATGCgaGBYWGDEjJR0oOjM9PDkzODdASFxOQERXRTc4UG1RV19iZ2hnPk1xeXBkeFxlZ2P/2wBDARESEhgVGC8aGi9jQjhCY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2P/wAARCAEOALoDASIAAhEBAxEB/8QAGgABAQEBAQEBAAAAAAAAAAAAAAECAwUEBv/EADwQAAIBAwIEBAMGAwYHAAAAAAABAgMEERIhBSIxQRNRYXEygZEUI6Gx0fAGQsEVJDNSwuEWQ1ODkrLS/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAECAwQF/8QAJREBAQACAgICAgIDAQAAAAAAAAECEQMhEjFBUQQTImEyQnGx/9oADAMBAAIRAxEAPwD8sADzvAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKCACggAoIAKCACggAoIAKCACggAoIAKCACggAoIAAAAAAAAAAAAAAAAAAAAMJgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAyAAAAAACggAoIAKCZAApGAKCACggAoIAKQBgG+UiXKV+RmL7BfhSojKEMlIAKCAAAGAAQAyop9QnmOPJ4LJ6YmYxb74/qGv8AqxfVfQqJLaOF5l69nt+INfKkc8TUfNBNHOVNNuWp7MsiyT5dQARlQZyZnUUc774Ksm+lc1pz8vmWPNuctOaXqt/c3DfpuFskjWH5lS0jIbIz2hSJ/iGCxcgIBAAAAAwMt8wTEnzGEw3Is3sj7Lyh4FSC6KdGnUXrmCf55PjmuU9r+I6Pg0eGVF/NZ04v3SM26ykdMcZljXkNZ9PUJLsSctMH7HKnPGz77pG5Nucxtju4nJQ1QrVH/LhLbu3+mTes6VIKHD6UMJeJU1P2Eb459uUZNt9ktsiq2oPfsZg+aSx0YqSenHXO2cj5TXbNN8iLVfRee+xmk+X2YrPmXljYvyuv5O0I6Y9um+xJTXnj5Eg+Tbd9TnOb6OKXnsT2mt11jLyeflgk3qkl82RPlQ9uoTXawfVsqeZGM6cxOkFykSxpAAMAAAoIAMzXKZS5cm5rlLbxU6sFNSazuordoslvUbxm2qVpVuIOcI5jhttvCzjpn6HufxBdWt9w+xp29alOrTpqMkpp46H2cMo2nhN3VpUrNPEKijGUItbYUc5XTrjsceK+DOTX2KvUSyk5qK2+oy4svKb+H0ePix1qPC4fZfbqk4VtdOEIpvHVt9PyZ9VXhPDqU9Ne+dOb3xJpEjcU7O2caC0zk3LQ3nSeTT/vFy3VqOT1Zcm+qPXMMZjPtzuOOPWn6Gnwjg9XCqcYpUsvHxRex7H/AAfaX1KlUp8Q1UorMHGKaZ+P4ZYwu+JfeYdCm9dVLZei/fqfouM8bqWnD8U24zqR001/lXmJhL2TGSbeHXpWVDizt6dZVqMZqEpyenvuzbp2VSGrli06ySUs50wWh9e8s+563Cp2lxwuFxUsLR1GpZfgxeWu/Q4cOvaN9UnCdjbU8LKxBPO+/YxeKbZ/W82pb2ivpU6c6fhOjJxfiJZnpbW+fMta2tfC+7nTdSNOElF1NpSxHXvntl7bfgepaSp3HD4XFS3opuDk0qaW/wBDxaN5L7YpzpU3Gaw4+GsJen6kyw8dbZyx127eFZQ8OMpwlH7zxHSqp4w5pacvyUcbb/MitrCOFOrCcPEUZ1IVMPRoi9ST75b2x6H2Xn2e3lHXbUWpT0NqCWOu/T0PN4pZwt5eJRWlPZpdmby4rj6W4a7bowt5UKc6ji9VKTk9eHCabxHT5bL65zsc71UI3tVW2HSjJqLTzqWevU9LhidxYq4rQoaI1PCWaccyxFb9PVHmVJOFe4pqEGnN76VlLscssNY+TOWGsdx82ebfz3O8Xy5OSgtXyOqXKcnDLuKwmSQRGGgQBAMMMKzN9jvYYjXz3Pt4bwG54jio3G3t/wDq1O/su570uF8F4dZVYJutWcWvElLdP07ImP5GHFnPl6MOLK9vGrRdapbKm5Rn4lVJxbWPP8T15/wxCNOEq9TXVmv56jy37nhWtz4N1TlU28OcovPbVvn6n6i4rU7zRUdeVPZao4z9Dl+ZyZ+ep1H1sMbMJlhN+v8AyPyXFLOdpVVObnKDfJJvmhI81z0Rc0kptYSS6Szj9T2f4mvIXFylDGfEz7Hx8IoqVed5VwqFu9nJ4Tn2/X6Hq/HuVxm3H8mS8nT1LGzhZ2Ko1pxh/wAyvlfE/wDL+/UzxPhU7mg7qvqhUe8Vn4F2TXn+p3oypSvqVKam0n4tZSnnV5JeSz29PUl66dt4jVZ1NUcLKxt6/T8x+TzXHKceLXFhdbuPTlwhOHBIQ7rWvxZ8drbVOE06dzfRnSq1KulU31UMPLfz7f7H2WFXVwtTg8fG19WeXZXD4k6NC4nqkquqTxjl0vyPVZuR5s59PVsW1wWksb6GvzPz9DGuDz2SPcspOfBqbb05hJtL3Z5ltQj9kuLiayo+HCHbmcll/Rfic+WWzFy5JuSPs45NaU99qv8ASQlTVxwZVG226Tx6uOV/pOfG393/AN7+kj7FB0uC0oJZk6MnFY7uUmvzR3vXJr+m5N5dsx/u3D+HUM5bhKbS85Zl/wCuk828hpu2+0op/P8AeD776tbUb5a3N+CtFOMU8NfDvt5RPkvo6fDeHlNxf7+RM8d8Vn0nJP46fH4ilLCT/Uqf78jlFuCxyL3Yy1v+2eHTzXH6dyr4jnGo3supuKMudlntQAGQqemX49MkAHeteXNbOu4qPbHxvofXwrhM7vFe6qeFbZ3k3vN+S/U+Gk4RqKVWGpLfTnGTvccQuLjZ1HGCWFGOyS8jNn09OFx951043TtKNzm0bUGsNSblh+Xng8+NxVjTxTqVYw8ovKPRsbWj4f2m7SlH+SMlnU/M8y8VJ15/Z6Ta3eFvpR0wss8a748t/wBenGUalWpClT1yqTklGLWMs/RqNHh1KCbU6Vom1tlTq95fLr84nmcFpOnB3j2lvCl/qf8AT5s+u8tKl9FQVzSoQjvLxFN6n8os9uGGp5L/AG/P1rmpVuJVtclUbzlPp6EqXNar/iVZS92exH+GZuOf7StMdfhq/wDwd7Kwt+E5u51ad1Xhl09MZKFPH8z1JZl5djn+u2+jdk072lvUtuFUqFem4VXBvQ3usttZ8jlY8M/s+VSpO4oVZyhpiqTlsu+cxXkeRayV7dzlc1J5nJ1Kklu9PxSfvjLPvnweELihCpdOEHUnTrSUsqDTisr/AM4fUv7J1uemfLt99tB0OG07apjxFT3Sfwt5eH67nCdtUjY07Ck4VakqilJwbw3ld3jZKJ8i4c6VsqtZTc4RzVp5w09c4fJLR9Wj6K/CYqhN0ajnU16YrGG94du2Ne/k16kvJj9Jc+3a8s1d11TlVVOmqmuc+uI79PNn0znC9ulUpRUbehKOXnZaVyQXm9l9GePOypfboUVOLpVoKpCrLpjS+uO2rbPbBihaePxD7NUlOlCMmsNrEHnSvT4sIt5t3ejzku9LcwuKvEGoU5uc5pU4pZcn0WD7r+jOca9vy69Wdmmk0/NHGPDvvKap1ZwnOk9DTw3V5o6PnKDRKHC6dWkmqiX3SqZbxvqjFw36Pm77dN99s48km9z2ky1bXlyouEXq2a7YNUVzPvt0OkVTjGaaqRqdNMl8O5mXJLK+Z57XG2+lhHEfM6IxjEkl0xk2jLlkAAMqCBgGyw0eItbejq8d0Y69SasbYwGo7XNadxLnelYworokZt/uadSo+r5V7GcEfPiD+CPX1ZqN45X2+aXiT/w9eF0SbWDi51tWNU89MZZ6JNK1Z2z5mpyVv9z5JQuIU9TqT26rLLbt1YyUnJ/M+zB88KXg3G3wyWPYedsJyWyysOg4y1UpaX74OlKnU0YcpRWfhT7mqr0LK6moSTjrWfX0ZnyumfPLSwqzdWD1zzCLjF5w8Z/3ZVKUdlJprLWHjGTk5NVdl16mkk3nutgl37I+JCWVKXkmm1heRGn1i8bYfqjoiT2jldt2vQm+08ra5Oc9a55aY9N+jNR8ScpOcpSztzNvJmpjwtunVG6b1U8l301bZGE8VZa9231NSWY7P0XqJR+9zhf7lS5v3sybS35FF9zaIVEYqggDIJAMDMnyklvjtuXSTZz9g3Gs4j3/AFJF5ySTfXst/cQ+L33BroqJ6dskU4RXc6JnGdN6njoUmr1W3WXbLLGWry+XmfMzpTblhLzyVq4yRusvoZpSztj6G6m+cmKeX0xtusknon+LbitXl2Lh+rX5BLVu9iy2iRnfwaVLf5BJR6FRQzv4fNUjiTS6dcG6PLtt1K+af4EktEvRl26W7mm5LMQny5YT7ftokl+pGf6WL7+ZpGYmgzQABAjKGAMNc/Qu4TDU6JfD7nNPHXOx0aMyjqkFlbjhdO+4bxL3OeXDZr1KpZkvJA0w48zXfr7nSlDTu+/4GsFb0l2XLc041HzYNZUI7GJPMsl0Py/ENa6bU0omJVHLYsafmZksSCTW3SnPO3obRwin1XY6Qn59yJZ9Klzv6mmYb0zNJhL9sw756la5g19TSBsQCAZAABSMADDGTTRGgsqZZpImkoKNEkuXYqAJdManITSwVrG5JvMg1GFF6jsYXxI2DKhJrMSkm+UJPbnB6ZG/hnsIRDXMFta2YYSDDJEpEVAqggCKCAAAADRChoAQACkAYAkvhIGg1CPxG8GUigoZZpkwElOkRFFaCQBBopACKggEAAAAAAAAAAAaGAAGAABBgoAhcAAMEKAICgCAoAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH/2Q==',
+        children: [
+          {
+            text: '',
+          },
+        ],
+      },
+    ]
+    it('should fix that collection', () => {
+      const exampleFromWildFixed = [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              text: 'A paragraph',
+            },
+          ],
+        },
+        {
+          type: 'numbered-list',
+          children: [
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: 'a numbered item,',
+                },
+              ],
+            },
+            {
+              type: 'list-item',
+              children: [
+                {
+                  text: 'another.',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'image-data',
+          data: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABALDA4MChAODQ4SERATGCgaGBYWGDEjJR0oOjM9PDkzODdASFxOQERXRTc4UG1RV19iZ2hnPk1xeXBkeFxlZ2P/2wBDARESEhgVGC8aGi9jQjhCY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2P/wAARCAEOALoDASIAAhEBAxEB/8QAGgABAQEBAQEBAAAAAAAAAAAAAAECAwUEBv/EADwQAAIBAwIEBAMGAwYHAAAAAAABAgMEERIhBSIxQRNRYXEygZEUI6Gx0fAGQsEVJDNSwuEWQ1ODkrLS/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAECAwQF/8QAJREBAQACAgICAgIDAQAAAAAAAAECEQMhEjFBUQQTImEyQnGx/9oADAMBAAIRAxEAPwD8sADzvAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKCACggAoIAKCACggAoIAKCACggAoIAKCACggAoIAAAAAAAAAAAAAAAAAAAAMJgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAyAAAAAACggAoIAKCZAApGAKCACggAoIAKQBgG+UiXKV+RmL7BfhSojKEMlIAKCAAAGAAQAyop9QnmOPJ4LJ6YmYxb74/qGv8AqxfVfQqJLaOF5l69nt+INfKkc8TUfNBNHOVNNuWp7MsiyT5dQARlQZyZnUUc774Ksm+lc1pz8vmWPNuctOaXqt/c3DfpuFskjWH5lS0jIbIz2hSJ/iGCxcgIBAAAAAwMt8wTEnzGEw3Is3sj7Lyh4FSC6KdGnUXrmCf55PjmuU9r+I6Pg0eGVF/NZ04v3SM26ykdMcZljXkNZ9PUJLsSctMH7HKnPGz77pG5Nucxtju4nJQ1QrVH/LhLbu3+mTes6VIKHD6UMJeJU1P2Eb459uUZNt9ktsiq2oPfsZg+aSx0YqSenHXO2cj5TXbNN8iLVfRee+xmk+X2YrPmXljYvyuv5O0I6Y9um+xJTXnj5Eg+Tbd9TnOb6OKXnsT2mt11jLyeflgk3qkl82RPlQ9uoTXawfVsqeZGM6cxOkFykSxpAAMAAAoIAMzXKZS5cm5rlLbxU6sFNSazuordoslvUbxm2qVpVuIOcI5jhttvCzjpn6HufxBdWt9w+xp29alOrTpqMkpp46H2cMo2nhN3VpUrNPEKijGUItbYUc5XTrjsceK+DOTX2KvUSyk5qK2+oy4svKb+H0ePix1qPC4fZfbqk4VtdOEIpvHVt9PyZ9VXhPDqU9Ne+dOb3xJpEjcU7O2caC0zk3LQ3nSeTT/vFy3VqOT1Zcm+qPXMMZjPtzuOOPWn6Gnwjg9XCqcYpUsvHxRex7H/AAfaX1KlUp8Q1UorMHGKaZ+P4ZYwu+JfeYdCm9dVLZei/fqfouM8bqWnD8U24zqR001/lXmJhL2TGSbeHXpWVDizt6dZVqMZqEpyenvuzbp2VSGrli06ySUs50wWh9e8s+563Cp2lxwuFxUsLR1GpZfgxeWu/Q4cOvaN9UnCdjbU8LKxBPO+/YxeKbZ/W82pb2ivpU6c6fhOjJxfiJZnpbW+fMta2tfC+7nTdSNOElF1NpSxHXvntl7bfgepaSp3HD4XFS3opuDk0qaW/wBDxaN5L7YpzpU3Gaw4+GsJen6kyw8dbZyx127eFZQ8OMpwlH7zxHSqp4w5pacvyUcbb/MitrCOFOrCcPEUZ1IVMPRoi9ST75b2x6H2Xn2e3lHXbUWpT0NqCWOu/T0PN4pZwt5eJRWlPZpdmby4rj6W4a7bowt5UKc6ji9VKTk9eHCabxHT5bL65zsc71UI3tVW2HSjJqLTzqWevU9LhidxYq4rQoaI1PCWaccyxFb9PVHmVJOFe4pqEGnN76VlLscssNY+TOWGsdx82ebfz3O8Xy5OSgtXyOqXKcnDLuKwmSQRGGgQBAMMMKzN9jvYYjXz3Pt4bwG54jio3G3t/wDq1O/su570uF8F4dZVYJutWcWvElLdP07ImP5GHFnPl6MOLK9vGrRdapbKm5Rn4lVJxbWPP8T15/wxCNOEq9TXVmv56jy37nhWtz4N1TlU28OcovPbVvn6n6i4rU7zRUdeVPZao4z9Dl+ZyZ+ep1H1sMbMJlhN+v8AyPyXFLOdpVVObnKDfJJvmhI81z0Rc0kptYSS6Szj9T2f4mvIXFylDGfEz7Hx8IoqVed5VwqFu9nJ4Tn2/X6Hq/HuVxm3H8mS8nT1LGzhZ2Ko1pxh/wAyvlfE/wDL+/UzxPhU7mg7qvqhUe8Vn4F2TXn+p3oypSvqVKam0n4tZSnnV5JeSz29PUl66dt4jVZ1NUcLKxt6/T8x+TzXHKceLXFhdbuPTlwhOHBIQ7rWvxZ8drbVOE06dzfRnSq1KulU31UMPLfz7f7H2WFXVwtTg8fG19WeXZXD4k6NC4nqkquqTxjl0vyPVZuR5s59PVsW1wWksb6GvzPz9DGuDz2SPcspOfBqbb05hJtL3Z5ltQj9kuLiayo+HCHbmcll/Rfic+WWzFy5JuSPs45NaU99qv8ASQlTVxwZVG226Tx6uOV/pOfG393/AN7+kj7FB0uC0oJZk6MnFY7uUmvzR3vXJr+m5N5dsx/u3D+HUM5bhKbS85Zl/wCuk828hpu2+0op/P8AeD776tbUb5a3N+CtFOMU8NfDvt5RPkvo6fDeHlNxf7+RM8d8Vn0nJP46fH4ilLCT/Uqf78jlFuCxyL3Yy1v+2eHTzXH6dyr4jnGo3supuKMudlntQAGQqemX49MkAHeteXNbOu4qPbHxvofXwrhM7vFe6qeFbZ3k3vN+S/U+Gk4RqKVWGpLfTnGTvccQuLjZ1HGCWFGOyS8jNn09OFx951043TtKNzm0bUGsNSblh+Xng8+NxVjTxTqVYw8ovKPRsbWj4f2m7SlH+SMlnU/M8y8VJ15/Z6Ta3eFvpR0wss8a748t/wBenGUalWpClT1yqTklGLWMs/RqNHh1KCbU6Vom1tlTq95fLr84nmcFpOnB3j2lvCl/qf8AT5s+u8tKl9FQVzSoQjvLxFN6n8os9uGGp5L/AG/P1rmpVuJVtclUbzlPp6EqXNar/iVZS92exH+GZuOf7StMdfhq/wDwd7Kwt+E5u51ad1Xhl09MZKFPH8z1JZl5djn+u2+jdk072lvUtuFUqFem4VXBvQ3usttZ8jlY8M/s+VSpO4oVZyhpiqTlsu+cxXkeRayV7dzlc1J5nJ1Kklu9PxSfvjLPvnweELihCpdOEHUnTrSUsqDTisr/AM4fUv7J1uemfLt99tB0OG07apjxFT3Sfwt5eH67nCdtUjY07Ck4VakqilJwbw3ld3jZKJ8i4c6VsqtZTc4RzVp5w09c4fJLR9Wj6K/CYqhN0ajnU16YrGG94du2Ne/k16kvJj9Jc+3a8s1d11TlVVOmqmuc+uI79PNn0znC9ulUpRUbehKOXnZaVyQXm9l9GePOypfboUVOLpVoKpCrLpjS+uO2rbPbBihaePxD7NUlOlCMmsNrEHnSvT4sIt5t3ejzku9LcwuKvEGoU5uc5pU4pZcn0WD7r+jOca9vy69Wdmmk0/NHGPDvvKap1ZwnOk9DTw3V5o6PnKDRKHC6dWkmqiX3SqZbxvqjFw36Pm77dN99s48km9z2ky1bXlyouEXq2a7YNUVzPvt0OkVTjGaaqRqdNMl8O5mXJLK+Z57XG2+lhHEfM6IxjEkl0xk2jLlkAAMqCBgGyw0eItbejq8d0Y69SasbYwGo7XNadxLnelYworokZt/uadSo+r5V7GcEfPiD+CPX1ZqN45X2+aXiT/w9eF0SbWDi51tWNU89MZZ6JNK1Z2z5mpyVv9z5JQuIU9TqT26rLLbt1YyUnJ/M+zB88KXg3G3wyWPYedsJyWyysOg4y1UpaX74OlKnU0YcpRWfhT7mqr0LK6moSTjrWfX0ZnyumfPLSwqzdWD1zzCLjF5w8Z/3ZVKUdlJprLWHjGTk5NVdl16mkk3nutgl37I+JCWVKXkmm1heRGn1i8bYfqjoiT2jldt2vQm+08ra5Oc9a55aY9N+jNR8ScpOcpSztzNvJmpjwtunVG6b1U8l301bZGE8VZa9231NSWY7P0XqJR+9zhf7lS5v3sybS35FF9zaIVEYqggDIJAMDMnyklvjtuXSTZz9g3Gs4j3/AFJF5ySTfXst/cQ+L33BroqJ6dskU4RXc6JnGdN6njoUmr1W3WXbLLGWry+XmfMzpTblhLzyVq4yRusvoZpSztj6G6m+cmKeX0xtusknon+LbitXl2Lh+rX5BLVu9iy2iRnfwaVLf5BJR6FRQzv4fNUjiTS6dcG6PLtt1K+af4EktEvRl26W7mm5LMQny5YT7ftokl+pGf6WL7+ZpGYmgzQABAjKGAMNc/Qu4TDU6JfD7nNPHXOx0aMyjqkFlbjhdO+4bxL3OeXDZr1KpZkvJA0w48zXfr7nSlDTu+/4GsFb0l2XLc041HzYNZUI7GJPMsl0Py/ENa6bU0omJVHLYsafmZksSCTW3SnPO3obRwin1XY6Qn59yJZ9Klzv6mmYb0zNJhL9sw756la5g19TSBsQCAZAABSMADDGTTRGgsqZZpImkoKNEkuXYqAJdManITSwVrG5JvMg1GFF6jsYXxI2DKhJrMSkm+UJPbnB6ZG/hnsIRDXMFta2YYSDDJEpEVAqggCKCAAAADRChoAQACkAYAkvhIGg1CPxG8GUigoZZpkwElOkRFFaCQBBopACKggEAAAAAAAAAAAaGAAGAABBgoAhcAAMEKAICgCAoAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH/2Q==',
+          children: [
+            {
+              text: '',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              text: '',
+            },
+          ],
+        },
+      ]
+      expect(normalize(dummyLog)(exampleFromWild)).toEqual(exampleFromWildFixed)
+    })
+  })
 })

--- a/lib/plottr_components/src/components/rce/helpers.js
+++ b/lib/plottr_components/src/components/rce/helpers.js
@@ -14,6 +14,7 @@ const { RCE_INITIAL_VALUE } = initialState
 
 export const LIST_TYPES = ['numbered-list', 'bulleted-list']
 export const HEADING_TYPES = ['heading-one', 'heading-two']
+export const IMAGE_TYPES = ['image-data', 'image-link']
 
 export function useTextConverter(text, log) {
   let rceText = text


### PR DESCRIPTION
# Motivation

Right now, if a user adds an image to the RCE, and it's the last element in the editor, they won't be able to add text after the image.
We'd like users to be able to have images as the last element and still add text afterwards.

# Approach

This PR adds a normaliser that ensures that an empty paragraph is added after images when they're the last element.