### PR TITLE
move update notifier to main

### DIFF
--- a/lib/plottr_components/src/components/dashboard/UpdateNotifier.js
+++ b/lib/plottr_components/src/components/dashboard/UpdateNotifier.js
@@ -9,7 +9,7 @@ import { Spinner } from '../Spinner'
 import Button from '../Button'
 import { checkDependencies } from '../checkDependencies'
 
-const updateCheckThreshold = 1000 * 60 * 60 * 3 // 3 hours
+const updateCheckThreshold = 1000 * 60 * 60 // 60 minutes
 
 const UpdateNotifierConnector = (connector) => {
   const {

--- a/lib/plottr_components/src/components/dashboard/navigation/DashboardBody.js
+++ b/lib/plottr_components/src/components/dashboard/navigation/DashboardBody.js
@@ -7,7 +7,6 @@ import UnconnectedBackupsHome from '../backups/BackupsHome'
 import UnconnectedOptionsHome from '../options/OptionsHome'
 import UnconnectedHelpHome from '../help/HelpHome'
 import UnconnectedDashboardErrorBoundary from '../../containers/DashboardErrorBoundary'
-import UnconnectedErrorBoundary from '../../containers/ErrorBoundary'
 import { checkDependencies } from '../../checkDependencies'
 
 const DashboardBodyConnector = (connector) => {

--- a/lib/plottr_components/src/components/dashboard/navigation/DashboardBody.js
+++ b/lib/plottr_components/src/components/dashboard/navigation/DashboardBody.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import PropTypes from 'react-proptypes'
 import UnconnectedAccountHome from '../account/AccountHome'
 import UnconnectedFilesHome from '../files/FilesHome'
-import UnconnectedUpdateNotifier from '../UpdateNotifier'
 import UnconnectedTemplatesHome from '../templates/TemplatesHome'
 import UnconnectedBackupsHome from '../backups/BackupsHome'
 import UnconnectedOptionsHome from '../options/OptionsHome'
@@ -27,10 +26,8 @@ const DashboardBodyConnector = (connector) => {
   })
 
   const DashboardErrorBoundary = UnconnectedDashboardErrorBoundary(connector)
-  const ErrorBoundary = UnconnectedErrorBoundary(connector)
   const AccountHome = UnconnectedAccountHome(connector)
   const FilesHome = UnconnectedFilesHome(connector)
-  const UpdateNotifier = UnconnectedUpdateNotifier(connector)
   const TemplatesHome = UnconnectedTemplatesHome(connector)
   const BackupsHome = UnconnectedBackupsHome(connector)
   const OptionsHome = UnconnectedOptionsHome(connector)
@@ -39,9 +36,6 @@ const DashboardBodyConnector = (connector) => {
   function Body({ children }) {
     return (
       <div className="dashboard__body">
-        <ErrorBoundary>
-          <UpdateNotifier />
-        </ErrorBoundary>
         <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
       </div>
     )

--- a/lib/plottr_components/src/components/index.js
+++ b/lib/plottr_components/src/components/index.js
@@ -113,6 +113,7 @@ import DashboardNav from './dashboard/navigation/DashboardNav'
 import ChoiceView from './dashboard/account/ChoiceView'
 import ExpiredView from './dashboard/account/ExpiredView'
 import ProOnboarding from './dashboard/account/proOnboarding/index'
+import UpdateNotifier from './dashboard/UpdateNotifier'
 
 // Firebase
 import FirebaseLogin from './FirebaseLogin'
@@ -209,5 +210,6 @@ export {
   ChoiceView,
   ExpiredView,
   ProOnboarding,
+  UpdateNotifier,
   connections,
 }

--- a/lib/plottr_components/src/connections/pltr.js
+++ b/lib/plottr_components/src/connections/pltr.js
@@ -90,6 +90,7 @@ import {
   ChoiceView as UnconnectedChoiceView,
   ExpiredView as UnconnectedExpiredView,
   ProOnboarding as UnconnectedProOnboarding,
+  UpdateNotifier as UnconnectedUpdateNotifier,
 } from '../components'
 
 const connector = {
@@ -336,5 +337,6 @@ export default (platform) => {
     ChoiceView: UnconnectedChoiceView(connectorObject),
     ExpiredView: UnconnectedExpiredView(connectorObject),
     ProOnboarding: UnconnectedProOnboarding(connectorObject),
+    UpdateNotifier: UnconnectedUpdateNotifier(connectorObject),
   }
 }

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -205,11 +205,9 @@ const App = ({
         <React.StrictMode>
           <Body />
         </React.StrictMode>
-        {!isOnWeb && (
-          <React.StrictMode>
-            <UpdateNotifier />
-          </React.StrictMode>
-        )}
+        <React.StrictMode>
+          <UpdateNotifier />
+        </React.StrictMode>
       </main>
       <React.StrictMode>
         <Spinner />
@@ -231,7 +229,6 @@ App.propTypes = {
   userNeedsToLogin: PropTypes.bool,
   sessionChecked: PropTypes.bool,
   clickOnDom: PropTypes.func,
-  isOnWeb: PropTypes.bool,
 }
 
 function mapStateToProps(state) {
@@ -242,7 +239,6 @@ function mapStateToProps(state) {
     isResuming: selectors.isResumingSelector(state.present),
     userNeedsToLogin: selectors.userNeedsToLoginSelector(state.present),
     sessionChecked: selectors.sessionCheckedSelector(state.present),
-    isOnWeb: selectors.isOnWebSelector(state.present),
   }
 }
 

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -33,7 +33,6 @@ const App = ({
   userNeedsToLogin,
   sessionChecked,
   clickOnDom,
-  isOnWeb,
 }) => {
   const [showTemplateCreate, setShowTemplateCreate] = useState(false)
   const [type, setType] = useState(null)

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -17,6 +17,7 @@ import {
   ErrorBoundary,
   ExportDialog,
   ActsHelpModal,
+  UpdateNotifier,
 } from 'connected-components'
 import { hasPreviousAction } from '../../common/utils/error_reporter'
 import { store } from '../store'
@@ -202,6 +203,9 @@ const App = ({
       >
         <React.StrictMode>
           <Body />
+        </React.StrictMode>
+        <React.StrictMode>
+          <UpdateNotifier />
         </React.StrictMode>
       </main>
       <React.StrictMode>

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -33,6 +33,7 @@ const App = ({
   userNeedsToLogin,
   sessionChecked,
   clickOnDom,
+  isOnWeb,
 }) => {
   const [showTemplateCreate, setShowTemplateCreate] = useState(false)
   const [type, setType] = useState(null)
@@ -204,9 +205,11 @@ const App = ({
         <React.StrictMode>
           <Body />
         </React.StrictMode>
-        <React.StrictMode>
-          <UpdateNotifier />
-        </React.StrictMode>
+        {!isOnWeb && (
+          <React.StrictMode>
+            <UpdateNotifier />
+          </React.StrictMode>
+        )}
       </main>
       <React.StrictMode>
         <Spinner />
@@ -228,6 +231,7 @@ App.propTypes = {
   userNeedsToLogin: PropTypes.bool,
   sessionChecked: PropTypes.bool,
   clickOnDom: PropTypes.func,
+  isOnWeb: PropTypes.bool,
 }
 
 function mapStateToProps(state) {
@@ -238,6 +242,7 @@ function mapStateToProps(state) {
     isResuming: selectors.isResumingSelector(state.present),
     userNeedsToLogin: selectors.userNeedsToLoginSelector(state.present),
     sessionChecked: selectors.sessionCheckedSelector(state.present),
+    isOnWeb: selectors.isOnWebSelector(state.present),
   }
 }
 

--- a/src/connected-components.js
+++ b/src/connected-components.js
@@ -512,3 +512,4 @@ export const FullPageSpinner = components.FullPageSpinner
 export const ChoiceView = components.ChoiceView
 export const ExpiredView = components.ExpiredView
 export const ProOnboarding = components.ProOnboarding
+export const UpdateNotifier = components.UpdateNotifier

--- a/src/css/dashboard/dashboard.scss
+++ b/src/css/dashboard/dashboard.scss
@@ -2,7 +2,7 @@
 @import 'navigation';
 @import 'verify';
 @import 'expired';
-@import 'update_notifier';
+@import '../update_notifier';
 @import 'files';
 @import 'templates';
 @import 'backups';

--- a/src/css/dashboard/update_notifier.scss
+++ b/src/css/dashboard/update_notifier.scss
@@ -40,7 +40,7 @@
 
   &.floating {
     position: absolute;
-    top: 50px;
+    bottom: 10px;
     right: 10px;
     margin: 0;
   }

--- a/src/css/dashboard/update_notifier.scss
+++ b/src/css/dashboard/update_notifier.scss
@@ -14,7 +14,7 @@
   align-items: center;
   margin: 10px 20px;
   margin-bottom: 0;
-  z-index: 10;
+  z-index: 1001;
 
   .update-notifier__buttons {
     display: flex;

--- a/src/css/update_notifier.scss
+++ b/src/css/update_notifier.scss
@@ -1,5 +1,5 @@
-@import "../colors";
-@import "../vars";
+@import "colors";
+@import "vars";
 
 @keyframes dot {
   0% { opacity: 0; }


### PR DESCRIPTION
Ticket: https://airtable.com/appfbr7vlSqIfZ9Sn/tblAmQkxs32m46J4N/viwW0oDccShKAvbCd/recDensRDfks80SJr?blocks=hide

@cameronsutter @Quiescent after i plucked it from the dashboard, the UpdateNotifier can no longer be seen on first load. Like when the user haven't pick any project to open. But when we open a project the component show up. Im not sure if i did it right, if i move the updatenotifier right 😅 Please see demo

Demo

https://user-images.githubusercontent.com/19387007/177183684-142bae3a-570d-440e-a759-c911af9df907.mp4

