### PR TITLE
Upgrade electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plottr",
-  "version": "2022.8.10-alpha.1",
+  "version": "2022.8.10-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "plottr",
-      "version": "2022.8.10-alpha.1",
+      "version": "2022.8.10-alpha.2",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@electron/remote": "^2.0.1",
@@ -62,7 +62,7 @@
         "dom-parser": "^0.1.6",
         "dotenv-webpack": "^7.1.0",
         "duplicate-package-checker-webpack-plugin": "^3.0.0",
-        "electron": "18.2.4",
+        "electron": "^18.3.0",
         "electron-builder": "^23.0.4",
         "electron-notarize": "^1.0.0",
         "enzyme": "^3.11.0",
@@ -264,6 +264,7 @@
     "lib/plottr_locales": {
       "version": "0.0.1",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "format-message": "^6.2.3"
       }
@@ -9608,9 +9609,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.4.tgz",
-      "integrity": "sha512-wSjU2N6kBGyGKb2GgBhujpfKtnmNr+gDaZZ6fMmlVMoPJ+GvuW0Zr1ImKPdb5zPXopPYmaURDSvHuAfSd4oHFA==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.0.tgz",
+      "integrity": "sha512-2+pAUIViVvFOGE5mJKKi8F6ruyvQrcqdfsm/AUfz+6P05vbvR5ZsR6WBkr90mlyojHW5w/nAVX9ZSOtz3aHs4A==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -34294,9 +34295,9 @@
       }
     },
     "electron": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.4.tgz",
-      "integrity": "sha512-wSjU2N6kBGyGKb2GgBhujpfKtnmNr+gDaZZ6fMmlVMoPJ+GvuW0Zr1ImKPdb5zPXopPYmaURDSvHuAfSd4oHFA==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.0.tgz",
+      "integrity": "sha512-2+pAUIViVvFOGE5mJKKi8F6ruyvQrcqdfsm/AUfz+6P05vbvR5ZsR6WBkr90mlyojHW5w/nAVX9ZSOtz3aHs4A==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^16.11.26",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "dom-parser": "^0.1.6",
     "dotenv-webpack": "^7.1.0",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
-    "electron": "18.2.4",
+    "electron": "^18.3.0",
     "electron-builder": "^23.0.4",
     "electron-notarize": "^1.0.0",
     "enzyme": "^3.11.0",
@@ -164,7 +164,7 @@
     "dmg-license": "^1.0.11"
   },
   "build": {
-    "electronVersion": "18.2.4",
+    "electronVersion": "18.3.0",
     "appId": "com.plottr.app",
     "artifactName": "${productName}-${os}-installer-latest.${ext}",
     "publish": [


### PR DESCRIPTION
# Motivation
There was a critical bug in Electron that could make the app deadlock on windows when acquiring the single instance lock.
This version includes the fix for that bug.