### PR TITLE
Add beat heading controls

### DIFF
--- a/lib/plottr_components/src/components/PlottrFloater.js
+++ b/lib/plottr_components/src/components/PlottrFloater.js
@@ -22,7 +22,9 @@ const PlottrFloaterConnector = (connector) => {
 
     const Component = useCallback(
       ({ position, childRect, popoverRect }) => {
-        return (
+        return hideArrow ? (
+          <SuppliedComponent />
+        ) : (
           <ArrowContainer
             position={position}
             childRect={childRect}

--- a/lib/plottr_components/src/components/PlottrFloater.js
+++ b/lib/plottr_components/src/components/PlottrFloater.js
@@ -11,6 +11,7 @@ const PlottrFloaterConnector = (connector) => {
     open,
     placement,
     align,
+    contentLocation,
     component,
     onClose,
     rootClose,
@@ -48,6 +49,7 @@ const PlottrFloaterConnector = (connector) => {
         isOpen={open}
         positions={[placement, ...['left', 'right', 'bottom', 'top']]}
         align={align}
+        contentLocation={contentLocation}
         padding={containerPadding}
         // FIXME: Root close on SelectLists is a bit finicky
         onClickOutside={rootClose ? onClose : () => {}}
@@ -66,6 +68,7 @@ const PlottrFloaterConnector = (connector) => {
     open: PropTypes.bool,
     placement: PropTypes.string.isRequired,
     align: PropTypes.string,
+    contentLocation: PropTypes.func,
     component: PropTypes.func.isRequired,
     onClose: PropTypes.func,
     rootClose: PropTypes.bool,

--- a/lib/plottr_components/src/components/PlottrFloater.js
+++ b/lib/plottr_components/src/components/PlottrFloater.js
@@ -10,6 +10,7 @@ const PlottrFloaterConnector = (connector) => {
     containerPadding,
     open,
     placement,
+    align,
     component,
     onClose,
     rootClose,
@@ -46,6 +47,7 @@ const PlottrFloaterConnector = (connector) => {
       <Popover
         isOpen={open}
         positions={[placement, ...['left', 'right', 'bottom', 'top']]}
+        align={align}
         padding={containerPadding}
         // FIXME: Root close on SelectLists is a bit finicky
         onClickOutside={rootClose ? onClose : () => {}}
@@ -63,6 +65,7 @@ const PlottrFloaterConnector = (connector) => {
     containerPadding: PropTypes.number,
     open: PropTypes.bool,
     placement: PropTypes.string.isRequired,
+    align: PropTypes.string,
     component: PropTypes.func.isRequired,
     onClose: PropTypes.func,
     rootClose: PropTypes.bool,

--- a/lib/plottr_components/src/components/domHelpers.js
+++ b/lib/plottr_components/src/components/domHelpers.js
@@ -1,6 +1,10 @@
-export const contains = (element, click) => {
-  const { left, top, right, bottom } = element.getBoundingClientRect()
-  const { x, y } = click
+export const boundingRectContains = (boundingRect, coord) => {
+  const { left, top, right, bottom } = boundingRect
+  const { x, y } = coord
 
   return x >= left && x <= right && y >= top && y <= bottom
+}
+
+export const contains = (element, click) => {
+  return boundingRectContains(element.getBoundingClientRect(), click)
 }

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -101,55 +101,73 @@ const BeatHeadingCellConnector = (connector) => {
       )
     }
 
+    const renderAddPeer = () => {
+      return (
+        <div>
+          <Button>
+            <Glyphicon glyph="plus" />
+          </Button>
+        </div>
+      )
+    }
+
     return (
       <Cell>
-        <div
-          className={cx('beat__heading-wrapper', {
-            'medium-timeline': isMedium,
-          })}
-          style={{ width: headingCellWidth, overflow: 'visible' }}
-          title={beatTitle}
-          onMouseEnter={startHovering}
-          onMouseLeave={stopHovering}
-          onDrop={handleDrop}
-        >
-          <Floater hideArrow={true} open={hovering} placement="bottom" component={renderControls}>
-            <div
-              style={{
-                ...hierarchyToStyles(
-                  hierarchyLevel,
-                  timelineSize,
-                  hovering === beatId || inDropZone,
-                  darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
-                  darkMode,
-                  featureFlags
-                ),
-                ...(isMedium ? {} : { padding: '10px 10px' }),
-                ...(!isMedium && width
-                  ? {
-                      width: width - 34,
-                    }
-                  : isMedium && width
-                  ? {
-                      width: width - 6,
-                    }
-                  : {}),
-              }}
-              className={cx('beat__heading', {
-                'medium-timeline': isMedium,
-              })}
-              onClick={startEditing}
-              draggable={!readOnly}
-              onDragStart={handleDragStart}
-              onDragEnd={handleDragEnd}
-              onDragEnter={handleDragEnter}
-              onDragOver={handleDragOver}
-              onDragLeave={handleDragLeave}
+        <Floater hideArrow={true} open={hovering} placement="right" component={renderAddPeer}>
+          <div
+            className={cx('beat__heading-wrapper', {
+              'medium-timeline': isMedium,
+            })}
+            style={{ width: headingCellWidth, overflow: 'visible' }}
+            title={beatTitle}
+            onMouseEnter={startHovering}
+            onMouseLeave={stopHovering}
+            onDrop={handleDrop}
+          >
+            <Floater
+              hideArrow={true}
+              open={hovering}
+              placement="bottom"
+              align="start"
+              component={renderControls}
             >
-              {renderTitle()}
-            </div>
-          </Floater>
-        </div>
+              <div
+                style={{
+                  ...hierarchyToStyles(
+                    hierarchyLevel,
+                    timelineSize,
+                    hovering === beatId || inDropZone,
+                    darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
+                    darkMode,
+                    featureFlags
+                  ),
+                  ...(isMedium ? {} : { padding: '10px 10px' }),
+                  ...(!isMedium && width
+                    ? {
+                        width: width - 34,
+                      }
+                    : isMedium && width
+                    ? {
+                        width: width - 6,
+                      }
+                    : {}),
+                }}
+                className={cx('beat__heading', {
+                  'medium-timeline': isMedium,
+                })}
+                onClick={startEditing}
+                draggable={!readOnly}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+                onDragEnter={handleDragEnter}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+              >
+                {renderTitle()}
+              </div>
+            </Floater>
+          </div>
+        </Floater>
       </Cell>
     )
   }

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -81,6 +81,9 @@ const BeatHeadingCellConnector = (connector) => {
     }
 
     const stopEditing = () => {
+      if (beat.title === '') {
+        editBeatTitle(beatId, currentTimeline, 'auto')
+      }
       setEditing(false)
     }
 

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -112,7 +112,7 @@ const BeatHeadingCellConnector = (connector) => {
     }
 
     return (
-      <Cell>
+      <Cell onMouseEnter={startHovering} onMouseLeave={stopHovering}>
         <Floater hideArrow={true} open={hovering} placement="right" component={renderAddPeer}>
           <div
             className={cx('beat__heading-wrapper', {
@@ -120,8 +120,6 @@ const BeatHeadingCellConnector = (connector) => {
             })}
             style={{ width: headingCellWidth, overflow: 'visible' }}
             title={beatTitle}
-            onMouseEnter={startHovering}
-            onMouseLeave={stopHovering}
             onDrop={handleDrop}
           >
             <Floater

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -13,6 +13,7 @@ import ButtonGroup from '../ButtonGroup'
 import FormGroup from '../FormGroup'
 import ControlLabel from '../ControlLabel'
 import FormControl from '../FormControl'
+import DeleteConfirmModal from '../dialogs/DeleteConfirmModal'
 import MousePositionContext from './MousePositionContext'
 import { boundingRectContains } from '../domHelpers'
 
@@ -41,10 +42,13 @@ const BeatHeadingCellConnector = (connector) => {
     insertBeat,
     editBeatTitle,
     beat,
+    hierarchyLevels,
+    deleteBeat,
   }) => {
     const [width, setWidth] = useState(null)
     const [headingCellWidth, setHeadingCellWidth] = useState(null)
     const [editing, setEditing] = useState(false)
+    const [deleting, setDeleting] = useState(false)
 
     const container = useRef(null)
     const bottomButtons = useRef(null)
@@ -71,12 +75,22 @@ const BeatHeadingCellConnector = (connector) => {
       // TODO
     }
 
-    const startEditing = () => {
+    const startEditing = (event) => {
+      event.stopPropagation()
       setEditing(true)
     }
 
     const stopEditing = () => {
       setEditing(false)
+    }
+
+    const startDeleting = (event) => {
+      event.stopPropagation()
+      setDeleting(true)
+    }
+
+    const stopDeleting = () => {
+      setDeleting(false)
     }
 
     const handleDragEnd = (_event) => {
@@ -99,6 +113,39 @@ const BeatHeadingCellConnector = (connector) => {
       // TODO
     }
 
+    const deleteThisBeat = (event) => {
+      event.stopPropagation()
+      deleteBeat(beatId, currentTimeline)
+    }
+
+    const renderDelete = () => {
+      if (!deleting) return null
+
+      const depth =
+        hierarchyLevels.length -
+        hierarchyLevels.findIndex(({ name }) => name === hierarchyLevel.name)
+
+      let warningMessage = null
+      switch (depth) {
+        case 1:
+          break
+        case 2:
+          warningMessage = `Are you sure you want to delete all scene cards in "${beatTitle}".`
+          break
+        case 3:
+          warningMessage = `Are you sure you want to delete all chapters and their scene cards in "${beatTitle}".`
+          break
+      }
+      return (
+        <DeleteConfirmModal
+          name={beatTitle}
+          customText={warningMessage && t(warningMessage)}
+          onDelete={deleteThisBeat}
+          onCancel={stopDeleting}
+        />
+      )
+    }
+
     const renderTitle = () => {
       return <span>{truncateTitle(beatTitle, 50)}</span>
     }
@@ -110,7 +157,7 @@ const BeatHeadingCellConnector = (connector) => {
             <Button title={`Edit ${beatTitle}`} bsSize="small" onClick={startEditing}>
               <Glyphicon glyph="edit" />
             </Button>
-            <Button title={`Delete ${beatTitle}`} bsSize="small">
+            <Button title={`Delete ${beatTitle}`} bsSize="small" onClick={startDeleting}>
               <Glyphicon glyph="trash" />
             </Button>
           </ButtonGroup>
@@ -189,85 +236,88 @@ const BeatHeadingCellConnector = (connector) => {
     }
 
     return (
-      <MousePositionContext.Consumer>
-        {(mouseCoord) => {
-          // TODO: postiion the buttons at the right edge
-          const hovering =
-            container.current && mouseCoord.x !== null && mouseCoord.y !== null
-              ? headingContains(mouseCoord) ||
-                bottomButtonsContain(mouseCoord) ||
-                rightButtonsContain(mouseCoord)
-              : false
-          return (
-            <Cell
-              ref={(ref) => {
-                container.current = ref
-              }}
-            >
-              <Floater
-                hideArrow={true}
-                open={hovering}
-                contentLocation={() => {
-                  if (container.current) {
-                    const { top, left } = container.current.getBoundingClientRect()
-                    return { top: top + 5, left: left + adjustedWidth() }
-                  }
-                  return { top: 0, left: 0 }
+      <>
+        {renderDelete()}
+        <MousePositionContext.Consumer>
+          {(mouseCoord) => {
+            // TODO: postiion the buttons at the right edge
+            const hovering =
+              container.current && mouseCoord.x !== null && mouseCoord.y !== null
+                ? headingContains(mouseCoord) ||
+                  bottomButtonsContain(mouseCoord) ||
+                  rightButtonsContain(mouseCoord)
+                : false
+            return (
+              <Cell
+                ref={(ref) => {
+                  container.current = ref
                 }}
-                component={renderAddPeer}
               >
-                <div
-                  className={cx('beat__heading-wrapper', {
-                    'medium-timeline': isMedium,
-                  })}
-                  style={{ width: headingCellWidth, overflow: 'visible' }}
-                  title={beatTitle}
-                  onDrop={handleDrop}
+                <Floater
+                  hideArrow={true}
+                  open={hovering}
+                  contentLocation={() => {
+                    if (container.current) {
+                      const { top, left } = container.current.getBoundingClientRect()
+                      return { top: top + 5, left: left + adjustedWidth() }
+                    }
+                    return { top: 0, left: 0 }
+                  }}
+                  component={renderAddPeer}
                 >
-                  <Floater
-                    hideArrow={true}
-                    open={hovering}
-                    placement="bottom"
-                    align="start"
-                    component={renderControls}
+                  <div
+                    className={cx('beat__heading-wrapper', {
+                      'medium-timeline': isMedium,
+                    })}
+                    style={{ width: headingCellWidth, overflow: 'visible' }}
+                    title={beatTitle}
+                    onDrop={handleDrop}
                   >
-                    <div
-                      style={{
-                        ...hierarchyToStyles(
-                          hierarchyLevel,
-                          timelineSize,
-                          hovering === beatId || inDropZone,
-                          darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
-                          darkMode,
-                          featureFlags
-                        ),
-                        ...(isMedium ? {} : { padding: '10px 10px' }),
-                        ...(width
-                          ? {
-                              width: adjustedWidth(),
-                            }
-                          : {}),
-                      }}
-                      className={cx('beat__heading', {
-                        'medium-timeline': isMedium,
-                      })}
-                      onClick={startEditing}
-                      draggable={!readOnly}
-                      onDragStart={handleDragStart}
-                      onDragEnd={handleDragEnd}
-                      onDragEnter={handleDragEnter}
-                      onDragOver={handleDragOver}
-                      onDragLeave={handleDragLeave}
+                    <Floater
+                      hideArrow={true}
+                      open={hovering}
+                      placement="bottom"
+                      align="start"
+                      component={renderControls}
                     >
-                      {renderTitle()}
-                    </div>
-                  </Floater>
-                </div>
-              </Floater>
-            </Cell>
-          )
-        }}
-      </MousePositionContext.Consumer>
+                      <div
+                        style={{
+                          ...hierarchyToStyles(
+                            hierarchyLevel,
+                            timelineSize,
+                            hovering === beatId || inDropZone,
+                            darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
+                            darkMode,
+                            featureFlags
+                          ),
+                          ...(isMedium ? {} : { padding: '10px 10px' }),
+                          ...(width
+                            ? {
+                                width: adjustedWidth(),
+                              }
+                            : {}),
+                        }}
+                        className={cx('beat__heading', {
+                          'medium-timeline': isMedium,
+                        })}
+                        onClick={startEditing}
+                        draggable={!readOnly}
+                        onDragStart={handleDragStart}
+                        onDragEnd={handleDragEnd}
+                        onDragEnter={handleDragEnter}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                      >
+                        {renderTitle()}
+                      </div>
+                    </Floater>
+                  </div>
+                </Floater>
+              </Cell>
+            )
+          }}
+        </MousePositionContext.Consumer>
+      </>
     )
   }
 
@@ -288,6 +338,8 @@ const BeatHeadingCellConnector = (connector) => {
     insertBeat: PropTypes.func.isRequired,
     editBeatTitle: PropTypes.func.isRequired,
     beat: PropTypes.object.isRequired,
+    hierarchyLevels: PropTypes.array.isRequired,
+    deleteBeat: PropTypes.func.isRequired,
   }
 
   const {
@@ -318,11 +370,13 @@ const BeatHeadingCellConnector = (connector) => {
           ),
           currentTimeline: selectors.currentTimelineSelector(state.present),
           beat: uniqueBeatsSelector(state.present, ownProps.beatId),
+          hierarchyLevels: selectors.sortedHierarchyLevels(state.present),
         }
       },
       {
         insertBeat: actions.beat.insertBeat,
         editBeatTitle: actions.beat.editBeatTitle,
+        deleteBeat: actions.beat.deleteBeat,
       }
     )(BeatHeadingCell)
   }

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -3,12 +3,16 @@ import PropTypes from 'prop-types'
 import { Cell } from 'react-sticky-table'
 import cx from 'classnames'
 
+import { t } from 'plottr_locales'
 import { helpers } from 'pltr/v2'
 
 import UnconnectedFloater from '../PlottrFloater'
 import Glyphicon from '../Glyphicon'
 import Button from '../Button'
 import ButtonGroup from '../ButtonGroup'
+import FormGroup from '../FormGroup'
+import ControlLabel from '../ControlLabel'
+import FormControl from '../FormControl'
 import MousePositionContext from './MousePositionContext'
 import { boundingRectContains } from '../domHelpers'
 
@@ -32,9 +36,15 @@ const BeatHeadingCellConnector = (connector) => {
     featureFlags,
     readOnly,
     beats,
+    hierarchyLevelName,
+    currentTimeline,
+    insertBeat,
+    editBeatTitle,
+    beat,
   }) => {
     const [width, setWidth] = useState(null)
     const [headingCellWidth, setHeadingCellWidth] = useState(null)
+    const [editing, setEditing] = useState(false)
 
     const container = useRef(null)
     const bottomButtons = useRef(null)
@@ -61,8 +71,12 @@ const BeatHeadingCellConnector = (connector) => {
       // TODO
     }
 
-    const startEditing = (_event) => {
-      // TODO
+    const startEditing = () => {
+      setEditing(true)
+    }
+
+    const stopEditing = () => {
+      setEditing(false)
     }
 
     const handleDragEnd = (_event) => {
@@ -93,18 +107,26 @@ const BeatHeadingCellConnector = (connector) => {
       return (
         <div ref={bottomButtons}>
           <ButtonGroup>
-            <Button bsSize="small">
-              <Glyphicon glyph="plus" />
+            <Button title={`Edit ${beatTitle}`} bsSize="small" onClick={startEditing}>
+              <Glyphicon glyph="edit" />
+            </Button>
+            <Button title={`Delete ${beatTitle}`} bsSize="small">
+              <Glyphicon glyph="trash" />
             </Button>
           </ButtonGroup>
         </div>
       )
     }
 
+    const insert = () => {
+      if (readOnly) return
+      insertBeat(currentTimeline, beatId)
+    }
+
     const renderAddPeer = () => {
       return (
         <div className="insert-beat-wrapper" ref={rightButtons}>
-          <Button bsSize="xs">
+          <Button bsSize="xs" title={t(`Insert ${hierarchyLevelName}`)} onClick={insert}>
             <Glyphicon glyph="plus" />
           </Button>
         </div>
@@ -140,6 +162,30 @@ const BeatHeadingCellConnector = (connector) => {
 
     const adjustedWidth = () => {
       return width - (isMedium ? 10 : 34)
+    }
+
+    const handleEsc = (event) => {
+      if (event.which === 27 || event.which === 13) {
+        setEditing(false)
+      }
+    }
+
+    if (editing) {
+      return (
+        <FormGroup>
+          <ControlLabel className={cx({ darkmode: darkMode })}>{beatTitle}</ControlLabel>
+          <FormControl
+            type="text"
+            onChange={(event) => {
+              editBeatTitle(beatId, currentTimeline, event.target.value)
+            }}
+            value={beat.title}
+            autoFocus
+            onKeyDown={handleEsc}
+            onBlur={stopEditing}
+          />
+        </FormGroup>
+      )
     }
 
     return (
@@ -237,30 +283,48 @@ const BeatHeadingCellConnector = (connector) => {
     featureFlags: PropTypes.object.isRequired,
     readOnly: PropTypes.bool,
     beats: PropTypes.array.isRequired,
+    hierarchyLevelName: PropTypes.string.isRequired,
+    currentTimeline: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    insertBeat: PropTypes.func.isRequired,
+    editBeatTitle: PropTypes.func.isRequired,
+    beat: PropTypes.object.isRequired,
   }
 
   const {
     redux,
-    pltr: { selectors },
+    pltr: { selectors, actions },
   } = connector
 
   if (redux) {
     const { connect } = redux
 
     const uniqueBeatTitleSelector = selectors.makeBeatTitleSelector()
+    const uniqueBeatsSelector = selectors.makeBeatSelector()
 
-    return connect((state, ownProps) => {
-      return {
-        beatTitle: uniqueBeatTitleSelector(state.present, ownProps.beatId),
-        isMedium: selectors.isMediumSelector(state.present),
-        hierarchyLevel: selectors.hierarchyLevelSelector(state.present, ownProps.beatId),
-        darkMode: selectors.isDarkModeSelector(state.present),
-        timelineSize: selectors.timelineSizeSelector(state.present),
-        featureFlags: selectors.featureFlags(state.present),
-        readOnly: !selectors.canWriteSelector(state.present),
-        beats: selectors.visibleSortedBeatsForTimelineByBookSelector(state.present),
+    return connect(
+      (state, ownProps) => {
+        return {
+          beatTitle: uniqueBeatTitleSelector(state.present, ownProps.beatId),
+          isMedium: selectors.isMediumSelector(state.present),
+          hierarchyLevel: selectors.hierarchyLevelSelector(state.present, ownProps.beatId),
+          darkMode: selectors.isDarkModeSelector(state.present),
+          timelineSize: selectors.timelineSizeSelector(state.present),
+          featureFlags: selectors.featureFlags(state.present),
+          readOnly: !selectors.canWriteSelector(state.present),
+          beats: selectors.visibleSortedBeatsForTimelineByBookSelector(state.present),
+          hierarchyLevelName: selectors.beatInsertControlHierarchyLevelNameSelector(
+            state.present,
+            ownProps.beatId
+          ),
+          currentTimeline: selectors.currentTimelineSelector(state.present),
+          beat: uniqueBeatsSelector(state.present, ownProps.beatId),
+        }
+      },
+      {
+        insertBeat: actions.beat.insertBeat,
+        editBeatTitle: actions.beat.editBeatTitle,
       }
-    })(BeatHeadingCell)
+    )(BeatHeadingCell)
   }
 
   throw new Error('Could not connect BeatHeadingCell!')

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Cell } from 'react-sticky-table'
 import cx from 'classnames'
@@ -8,6 +8,8 @@ import { helpers } from 'pltr/v2'
 import UnconnectedFloater from '../PlottrFloater'
 import Glyphicon from '../Glyphicon'
 import Button from '../Button'
+import MousePositionContext from './MousePositionContext'
+import { boundingRectContains } from '../domHelpers'
 
 const {
   card: { truncateTitle },
@@ -30,9 +32,10 @@ const BeatHeadingCellConnector = (connector) => {
     readOnly,
     beats,
   }) => {
-    const [hovering, setHovering] = useState(false)
     const [width, setWidth] = useState(null)
     const [headingCellWidth, setHeadingCellWidth] = useState(null)
+
+    const container = useRef(null)
 
     useEffect(() => {
       const aBeatTitleCell = document.querySelector('.beat-table-cell')
@@ -50,14 +53,6 @@ const BeatHeadingCellConnector = (connector) => {
         }
       }
     }, [setWidth, setHeadingCellWidth, beats])
-
-    const startHovering = (_event) => {
-      setHovering(true)
-    }
-
-    const stopHovering = (_event) => {
-      setHovering(false)
-    }
 
     const handleDrop = (_event) => {
       // TODO
@@ -111,62 +106,86 @@ const BeatHeadingCellConnector = (connector) => {
       )
     }
 
+    const extend = (boundingClientRect) => {
+      return {
+        left: boundingClientRect.left,
+        top: boundingClientRect.top,
+        bottom: boundingClientRect.bottom,
+        right: boundingClientRect.left + width,
+      }
+    }
+
     return (
-      <Cell onMouseEnter={startHovering} onMouseLeave={stopHovering}>
-        <Floater hideArrow={true} open={hovering} placement="right" component={renderAddPeer}>
-          <div
-            className={cx('beat__heading-wrapper', {
-              'medium-timeline': isMedium,
-            })}
-            style={{ width: headingCellWidth, overflow: 'visible' }}
-            title={beatTitle}
-            onDrop={handleDrop}
-          >
-            <Floater
-              hideArrow={true}
-              open={hovering}
-              placement="bottom"
-              align="start"
-              component={renderControls}
+      <MousePositionContext.Consumer>
+        {(mouseCoord) => {
+          // TODO: include the buttons in the computation
+          const hovering =
+            container.current && mouseCoord.x !== null && mouseCoord.y !== null
+              ? boundingRectContains(extend(container.current.getBoundingClientRect()), mouseCoord)
+              : false
+          return (
+            <Cell
+              ref={(ref) => {
+                container.current = ref
+              }}
             >
-              <div
-                style={{
-                  ...hierarchyToStyles(
-                    hierarchyLevel,
-                    timelineSize,
-                    hovering === beatId || inDropZone,
-                    darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
-                    darkMode,
-                    featureFlags
-                  ),
-                  ...(isMedium ? {} : { padding: '10px 10px' }),
-                  ...(!isMedium && width
-                    ? {
-                        width: width - 34,
-                      }
-                    : isMedium && width
-                    ? {
-                        width: width - 6,
-                      }
-                    : {}),
-                }}
-                className={cx('beat__heading', {
-                  'medium-timeline': isMedium,
-                })}
-                onClick={startEditing}
-                draggable={!readOnly}
-                onDragStart={handleDragStart}
-                onDragEnd={handleDragEnd}
-                onDragEnter={handleDragEnter}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-              >
-                {renderTitle()}
-              </div>
-            </Floater>
-          </div>
-        </Floater>
-      </Cell>
+              <Floater hideArrow={true} open={hovering} placement="right" component={renderAddPeer}>
+                <div
+                  className={cx('beat__heading-wrapper', {
+                    'medium-timeline': isMedium,
+                  })}
+                  style={{ width: headingCellWidth, overflow: 'visible' }}
+                  title={beatTitle}
+                  onDrop={handleDrop}
+                >
+                  <Floater
+                    hideArrow={true}
+                    open={hovering}
+                    placement="bottom"
+                    align="start"
+                    component={renderControls}
+                  >
+                    <div
+                      style={{
+                        ...hierarchyToStyles(
+                          hierarchyLevel,
+                          timelineSize,
+                          hovering === beatId || inDropZone,
+                          darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
+                          darkMode,
+                          featureFlags
+                        ),
+                        ...(isMedium ? {} : { padding: '10px 10px' }),
+                        ...(!isMedium && width
+                          ? {
+                              width: width - 34,
+                            }
+                          : isMedium && width
+                          ? {
+                              width: width - 10,
+                            }
+                          : {}),
+                      }}
+                      className={cx('beat__heading', {
+                        'medium-timeline': isMedium,
+                      })}
+                      onClick={startEditing}
+                      draggable={!readOnly}
+                      onDragStart={handleDragStart}
+                      onDragEnd={handleDragEnd}
+                      onDragEnter={handleDragEnter}
+                      onDragOver={handleDragOver}
+                      onDragLeave={handleDragLeave}
+                    >
+                      {renderTitle()}
+                    </div>
+                  </Floater>
+                </div>
+              </Floater>
+            </Cell>
+          )
+        }}
+      </MousePositionContext.Consumer>
     )
   }
 

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -5,12 +5,18 @@ import cx from 'classnames'
 
 import { helpers } from 'pltr/v2'
 
+import UnconnectedFloater from '../PlottrFloater'
+import Glyphicon from '../Glyphicon'
+import Button from '../Button'
+
 const {
   card: { truncateTitle },
   hierarchyLevels: { hierarchyToStyles },
 } = helpers
 
 const BeatHeadingCellConnector = (connector) => {
+  const Floater = UnconnectedFloater(connector)
+
   const BeatHeadingCell = ({
     span,
     beatId,
@@ -85,6 +91,16 @@ const BeatHeadingCellConnector = (connector) => {
       return <span>{truncateTitle(beatTitle, 50)}</span>
     }
 
+    const renderControls = () => {
+      return (
+        <div>
+          <Button>
+            <Glyphicon glyph="plus" />
+          </Button>
+        </div>
+      )
+    }
+
     return (
       <Cell>
         <div
@@ -97,40 +113,42 @@ const BeatHeadingCellConnector = (connector) => {
           onMouseLeave={stopHovering}
           onDrop={handleDrop}
         >
-          <div
-            style={{
-              ...hierarchyToStyles(
-                hierarchyLevel,
-                timelineSize,
-                hovering === beatId || inDropZone,
-                darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
-                darkMode,
-                featureFlags
-              ),
-              ...(isMedium ? {} : { padding: '10px 10px' }),
-              ...(!isMedium && width
-                ? {
-                    width: width - 34,
-                  }
-                : isMedium && width
-                ? {
-                    width: width - 6,
-                  }
-                : {}),
-            }}
-            className={cx('beat__heading', {
-              'medium-timeline': isMedium,
-            })}
-            onClick={startEditing}
-            draggable={!readOnly}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            onDragEnter={handleDragEnter}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-          >
-            {renderTitle()}
-          </div>
+          <Floater hideArrow={true} open={hovering} placement="bottom" component={renderControls}>
+            <div
+              style={{
+                ...hierarchyToStyles(
+                  hierarchyLevel,
+                  timelineSize,
+                  hovering === beatId || inDropZone,
+                  darkMode === true ? hierarchyLevel.dark : hierarchyLevel.light,
+                  darkMode,
+                  featureFlags
+                ),
+                ...(isMedium ? {} : { padding: '10px 10px' }),
+                ...(!isMedium && width
+                  ? {
+                      width: width - 34,
+                    }
+                  : isMedium && width
+                  ? {
+                      width: width - 6,
+                    }
+                  : {}),
+              }}
+              className={cx('beat__heading', {
+                'medium-timeline': isMedium,
+              })}
+              onClick={startEditing}
+              draggable={!readOnly}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onDragEnter={handleDragEnter}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+            >
+              {renderTitle()}
+            </div>
+          </Floater>
         </div>
       </Cell>
     )

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -36,6 +36,8 @@ const BeatHeadingCellConnector = (connector) => {
     const [headingCellWidth, setHeadingCellWidth] = useState(null)
 
     const container = useRef(null)
+    const bottomButtons = useRef(null)
+    const rightButtons = useRef(null)
 
     useEffect(() => {
       const aBeatTitleCell = document.querySelector('.beat-table-cell')
@@ -88,7 +90,7 @@ const BeatHeadingCellConnector = (connector) => {
 
     const renderControls = () => {
       return (
-        <div>
+        <div ref={bottomButtons}>
           <Button>
             <Glyphicon glyph="plus" />
           </Button>
@@ -98,7 +100,7 @@ const BeatHeadingCellConnector = (connector) => {
 
     const renderAddPeer = () => {
       return (
-        <div>
+        <div ref={rightButtons}>
           <Button>
             <Glyphicon glyph="plus" />
           </Button>
@@ -115,13 +117,34 @@ const BeatHeadingCellConnector = (connector) => {
       }
     }
 
+    const headingContains = (mouseCoord) => {
+      return boundingRectContains(extend(container.current.getBoundingClientRect()), mouseCoord)
+    }
+
+    const bottomButtonsContain = (mouseCoord) => {
+      return (
+        bottomButtons.current &&
+        boundingRectContains(bottomButtons.current.getBoundingClientRect(), mouseCoord)
+      )
+    }
+
+    const rightButtonsContain = (mouseCoord) => {
+      return (
+        rightButtons.current &&
+        boundingRectContains(rightButtons.current.getBoundingClientRect(), mouseCoord)
+      )
+    }
+
     return (
       <MousePositionContext.Consumer>
         {(mouseCoord) => {
+          // TODO: postiion the buttons at the right edge
           // TODO: include the buttons in the computation
           const hovering =
             container.current && mouseCoord.x !== null && mouseCoord.y !== null
-              ? boundingRectContains(extend(container.current.getBoundingClientRect()), mouseCoord)
+              ? headingContains(mouseCoord) ||
+                bottomButtonsContain(mouseCoord) ||
+                rightButtonsContain(mouseCoord)
               : false
           return (
             <Cell

--- a/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
+++ b/lib/plottr_components/src/components/timeline/BeatHeadingCell.js
@@ -8,6 +8,7 @@ import { helpers } from 'pltr/v2'
 import UnconnectedFloater from '../PlottrFloater'
 import Glyphicon from '../Glyphicon'
 import Button from '../Button'
+import ButtonGroup from '../ButtonGroup'
 import MousePositionContext from './MousePositionContext'
 import { boundingRectContains } from '../domHelpers'
 
@@ -91,17 +92,19 @@ const BeatHeadingCellConnector = (connector) => {
     const renderControls = () => {
       return (
         <div ref={bottomButtons}>
-          <Button>
-            <Glyphicon glyph="plus" />
-          </Button>
+          <ButtonGroup>
+            <Button bsSize="small">
+              <Glyphicon glyph="plus" />
+            </Button>
+          </ButtonGroup>
         </div>
       )
     }
 
     const renderAddPeer = () => {
       return (
-        <div ref={rightButtons}>
-          <Button>
+        <div className="insert-beat-wrapper" ref={rightButtons}>
+          <Button bsSize="xs">
             <Glyphicon glyph="plus" />
           </Button>
         </div>
@@ -113,7 +116,7 @@ const BeatHeadingCellConnector = (connector) => {
         left: boundingClientRect.left,
         top: boundingClientRect.top,
         bottom: boundingClientRect.bottom,
-        right: boundingClientRect.left + width,
+        right: boundingClientRect.left + adjustedWidth(),
       }
     }
 
@@ -135,11 +138,14 @@ const BeatHeadingCellConnector = (connector) => {
       )
     }
 
+    const adjustedWidth = () => {
+      return width - (isMedium ? 10 : 34)
+    }
+
     return (
       <MousePositionContext.Consumer>
         {(mouseCoord) => {
           // TODO: postiion the buttons at the right edge
-          // TODO: include the buttons in the computation
           const hovering =
             container.current && mouseCoord.x !== null && mouseCoord.y !== null
               ? headingContains(mouseCoord) ||
@@ -152,7 +158,18 @@ const BeatHeadingCellConnector = (connector) => {
                 container.current = ref
               }}
             >
-              <Floater hideArrow={true} open={hovering} placement="right" component={renderAddPeer}>
+              <Floater
+                hideArrow={true}
+                open={hovering}
+                contentLocation={() => {
+                  if (container.current) {
+                    const { top, left } = container.current.getBoundingClientRect()
+                    return { top: top + 5, left: left + adjustedWidth() }
+                  }
+                  return { top: 0, left: 0 }
+                }}
+                component={renderAddPeer}
+              >
                 <div
                   className={cx('beat__heading-wrapper', {
                     'medium-timeline': isMedium,
@@ -179,13 +196,9 @@ const BeatHeadingCellConnector = (connector) => {
                           featureFlags
                         ),
                         ...(isMedium ? {} : { padding: '10px 10px' }),
-                        ...(!isMedium && width
+                        ...(width
                           ? {
-                              width: width - 34,
-                            }
-                          : isMedium && width
-                          ? {
-                              width: width - 10,
+                              width: adjustedWidth(),
                             }
                           : {}),
                       }}

--- a/lib/plottr_components/src/components/timeline/MousePositionContext.js
+++ b/lib/plottr_components/src/components/timeline/MousePositionContext.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+const MousePositionContext = React.createContext({
+  x: null,
+  y: null,
+})
+
+export default MousePositionContext

--- a/lib/plottr_components/src/components/timeline/TopRow.js
+++ b/lib/plottr_components/src/components/timeline/TopRow.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import PropTypes from 'react-proptypes'
 import { Row, Cell } from 'react-sticky-table'
 
@@ -11,6 +11,7 @@ import UnconnectedLineTitleCell from './LineTitleCell'
 import UnconnectedBeatInsertCell from './BeatInsertCell'
 import UnconnectedAddLineColumn from './AddLineColumn'
 import { checkDependencies } from '../checkDependencies'
+import MousePositionContext from '../../../dist/components/timeline/MousePositionContext'
 
 const {
   beats: { nextId, hasChildren },
@@ -25,74 +26,79 @@ const TopRowConnector = (connector) => {
   const BeatInsertCell = UnconnectedBeatInsertCell(connector)
   const AddLineColumn = UnconnectedAddLineColumn(connector)
 
-  class TopRow extends Component {
-    constructor(props) {
-      super(props)
-      this.state = {
-        hovering: null,
+  const TopRow = (props) => {
+    const [hovering, setHovering] = useState(false)
+    const [mouseXY, setMouseXY] = useState({ x: null, y: null })
+
+    const firstCell = useRef(null)
+
+    useEffect(() => {
+      if (firstCell.current) {
+        firstCell.current.style.zIndex = 101
       }
-
-      this.firstCell = null
-    }
-
-    componentDidMount() {
-      if (this.firstCell) {
-        this.firstCell.style.zIndex = 101
+      const mouseMoveListener = document.addEventListener('mousemove', (event) => {
+        setMouseXY({
+          x: event.pageX,
+          y: event.pageY,
+        })
+      })
+      return () => {
+        document.removeEventListener('mousemove', mouseMoveListener)
       }
-    }
+    }, [])
 
-    handleReorderBeats = (droppedPositionId, originalPositionId) => {
-      const { currentTimeline, beatActions } = this.props
+    const handleReorderBeats = (droppedPositionId, originalPositionId) => {
+      const { currentTimeline, beatActions } = props
       beatActions.reorderBeats(originalPositionId, droppedPositionId, currentTimeline)
     }
 
-    handleReorderLines = (originalPosition, droppedPosition) => {
-      const { currentTimeline, lineActions, lines } = this.props
+    const handleReorderLines = (originalPosition, droppedPosition) => {
+      const { currentTimeline, lineActions, lines } = props
       const newLines = reorderList(originalPosition, droppedPosition, lines)
       lineActions.reorderLines(newLines, currentTimeline)
     }
 
-    startHovering = (beat) => {
-      this.setState({ hovering: beat })
+    const startHovering = (beat) => {
+      setHovering(beat)
       return beat
     }
 
-    stopHovering = () => {
-      this.setState({ hovering: null })
+    const stopHovering = () => {
+      setHovering(null)
       return null
     }
 
-    handleInsertNewBeat = (peerBeatId) => {
-      const { currentTimeline, beatActions } = this.props
+    const handleInsertNewBeat = (peerBeatId) => {
+      const { currentTimeline, beatActions } = props
       beatActions.insertBeat(currentTimeline, peerBeatId)
     }
 
-    handleInsertChildBeat = (beatToLeftId) => {
-      const { currentTimeline, beatActions } = this.props
+    const handleInsertChildBeat = (beatToLeftId) => {
+      const { currentTimeline, beatActions } = props
       beatActions.expandBeat(beatToLeftId, currentTimeline)
       beatActions.addBeat(currentTimeline, beatToLeftId)
     }
 
-    handleAppendBeat = () => {
-      const { currentTimeline, beatActions, beats, timelineViewIsTabbed, activeTab } = this.props
+    const handleAppendBeat = () => {
+      const { currentTimeline, beatActions, beats, timelineViewIsTabbed, activeTab } = props
       if (timelineViewIsTabbed) {
         if (beats.length === 0) {
-          this.handleInsertChildBeat(activeTab, currentTimeline)
+          handleInsertChildBeat(activeTab, currentTimeline)
           return
         } else {
-          this.handleInsertNewBeat(beats[beats.length - 1].id)
+          handleInsertNewBeat(beats[beats.length - 1].id)
           return
         }
       }
       beatActions.addBeat(currentTimeline)
     }
 
-    handleAppendLine = () => {
-      const { currentTimeline, lineActions } = this.props
+    const handleAppendLine = () => {
+      const { currentTimeline, lineActions } = props
       lineActions.addLine(currentTimeline)
     }
 
-    renderSecondLastInsertBeatCell() {
+    const renderSecondLastInsertBeatCell = () => {
       const {
         timelineViewIsStacked,
         currentTimeline,
@@ -102,7 +108,7 @@ const TopRowConnector = (connector) => {
         booksBeats,
         beats,
         beatActions,
-      } = this.props
+      } = props
       if (!isLarge && !isMedium) return null
 
       const lastBeat = !beats || beats.length === 0 ? null : beats[beats.length - 1]
@@ -110,12 +116,12 @@ const TopRowConnector = (connector) => {
         <BeatInsertCell
           key="second-last-insert"
           isInBeatList={true}
-          handleInsert={this.handleInsertNewBeat}
+          handleInsert={handleInsertNewBeat}
           beatToLeft={lastBeat}
           handleInsertChild={
             lastBeat && hasChildren(booksBeats, lastBeat && lastBeat.id)
               ? undefined
-              : this.handleInsertChildBeat
+              : handleInsertChildBeat
           }
           expanded={lastBeat && lastBeat.expanded}
           toggleExpanded={() => {
@@ -124,19 +130,19 @@ const TopRowConnector = (connector) => {
             } else beatActions.expandBeat(lastBeat.id, currentTimeline)
           }}
           orientation={orientation}
-          hovering={this.state.hovering}
-          onMouseEnter={() => this.startHovering(lastBeat.id)}
-          onMouseLeave={this.stopHovering}
+          hovering={hovering}
+          onMouseEnter={() => startHovering(lastBeat.id)}
+          onMouseLeave={stopHovering}
         />
       )
     }
 
-    renderLastInsertBeatCell() {
-      const { orientation } = this.props
+    const renderLastInsertBeatCell = () => {
+      const { orientation } = props
       return (
         <BeatInsertCell
           key="last-insert"
-          handleInsert={this.handleAppendBeat}
+          handleInsert={handleAppendBeat}
           isInBeatList={true}
           isLast={true}
           orientation={orientation}
@@ -144,7 +150,7 @@ const TopRowConnector = (connector) => {
       )
     }
 
-    renderBeats() {
+    const renderBeats = () => {
       const {
         currentTimeline,
         orientation,
@@ -155,7 +161,7 @@ const TopRowConnector = (connector) => {
         isMedium,
         isSmall,
         timelineViewIsStacked,
-      } = this.props
+      } = props
       const beatToggler = (beat) => () => {
         if (!beat) return
         if (beat.expanded) beatActions.collapseBeat(beat.id, currentTimeline)
@@ -174,15 +180,15 @@ const TopRowConnector = (connector) => {
                 key={`beatId-${beat.id}-insert`}
                 isInBeatList={true}
                 beatToLeft={lastBeat}
-                handleInsert={this.handleInsertNewBeat}
-                handleInsertChild={this.handleInsertChildBeat}
+                handleInsert={handleInsertNewBeat}
+                handleInsertChild={handleInsertChildBeat}
                 expanded={lastBeat && lastBeat.expanded}
                 toggleExpanded={beatToggler(lastBeat)}
                 orientation={orientation}
                 // this hovering state is the id of the card the user is currently hovering over
-                hovering={this.state.hovering}
-                onMouseEnter={() => this.startHovering(beat.id)}
-                onMouseLeave={this.stopHovering}
+                hovering={hovering}
+                onMouseEnter={() => startHovering(beat.id)}
+                onMouseLeave={stopHovering}
               />
             )
           }
@@ -193,9 +199,9 @@ const TopRowConnector = (connector) => {
               key={`beatId-${beat.id}-insert-child`}
               isInBeatList={true}
               isInsertChildCell
-              handleInsert={this.handleInsertChildBeat}
+              handleInsert={handleInsertChildBeat}
               beatToLeft={beat}
-              handleInsertChild={this.handleInsertChildBeat}
+              handleInsertChild={handleInsertChildBeat}
               expanded
               toggleExpanded={() => {
                 // Can't collapse this insert cell
@@ -212,32 +218,32 @@ const TopRowConnector = (connector) => {
               isFirst={idx === 0}
               key={`beatId-${beat.id}`}
               beatId={beat.id}
-              handleReorder={this.handleReorderBeats}
-              handleInsert={this.handleInsertNewBeat}
+              handleReorder={handleReorderBeats}
+              handleInsert={handleInsertNewBeat}
               handleInsertChild={
                 lastBeat && hasChildren(booksBeats, lastBeat && lastBeat.id)
                   ? undefined
-                  : this.handleInsertChildBeat
+                  : handleInsertChildBeat
               }
-              hovering={this.state.hovering}
-              onMouseEnter={() => this.startHovering(beat.id)}
-              onMouseLeave={this.stopHovering}
+              hovering={hovering}
+              onMouseEnter={() => startHovering(beat.id)}
+              onMouseLeave={stopHovering}
             />
           )
         }
         return cells
       })
       if (isSmall) {
-        return [...renderedBeats, this.renderLastInsertBeatCell()]
+        return [...renderedBeats, renderLastInsertBeatCell()]
       } else if (!beats.length) {
         return [
           <Cell
             key="placeholder"
             ref={(ref) => {
-              this.firstCell = ref
+              firstCell.current = ref
             }}
           />,
-          this.renderLastInsertBeatCell(),
+          renderLastInsertBeatCell(),
         ]
       } else {
         return [
@@ -245,22 +251,22 @@ const TopRowConnector = (connector) => {
             style={{ zIndex: 101 }}
             key="placeholder"
             ref={(ref) => {
-              this.firstCell = ref
+              firstCell.current = ref
             }}
           />,
           ...renderedBeats,
-          this.renderSecondLastInsertBeatCell(),
+          renderSecondLastInsertBeatCell(),
         ]
       }
     }
 
-    renderLines() {
-      const { lines, currentTimeline, orientation, isSmall, isMedium, isLarge } = this.props
+    const renderLines = () => {
+      const { lines, currentTimeline, orientation, isSmall, isMedium, isLarge } = props
       const renderedLines = lines.map((line, index) => (
         <LineTitleCell
           key={`line-${line.id}`}
           line={line}
-          handleReorder={this.handleReorderLines}
+          handleReorder={handleReorderLines}
           bookId={currentTimeline}
           zIndex={100 - index}
         />
@@ -268,7 +274,7 @@ const TopRowConnector = (connector) => {
       const insertLineDiv = (
         <div
           className={orientedClassName('line-list__append-line--small', orientation)}
-          onClick={this.handleAppendLine}
+          onClick={handleAppendLine}
         >
           <div className={orientedClassName('line-list__append-line-wrapper--small', orientation)}>
             <Glyphicon glyph="plus" />
@@ -297,8 +303,8 @@ const TopRowConnector = (connector) => {
       return finalArray
     }
 
-    renderPaddingCells(beatId, count) {
-      const { isLarge } = this.props
+    const renderPaddingCells = (beatId, count) => {
+      const { isLarge } = props
       const paddingCells = []
       for (let i = 0; i < count; ++i) {
         paddingCells.push(
@@ -313,8 +319,8 @@ const TopRowConnector = (connector) => {
       return paddingCells
     }
 
-    renderTieredBeats(beats, leavesPerBeat, hierarchyLevelConfig) {
-      const { isLarge } = this.props
+    const renderTieredBeats = (beats, leavesPerBeat, hierarchyLevelConfig) => {
+      const { isLarge } = props
       return [
         <Cell key="placeholder" style={{ zIndex: 101 }} />,
         ...beats.flatMap((beat, index) => {
@@ -322,56 +328,57 @@ const TopRowConnector = (connector) => {
           return [
             isLarge ? <Cell key={`place-holder${index}`} /> : null,
             <BeatHeadingCell key={`beatId-${beat.id}`} span={beatLeaves} beatId={beat.id} />,
-            ...this.renderPaddingCells(beat.id, beatLeaves - 1),
+            ...renderPaddingCells(beat.id, beatLeaves - 1),
           ]
         }),
       ]
     }
 
-    render() {
-      const {
-        orientation,
-        isSmall,
-        timelineViewIsStacked,
-        topTierBeats,
-        secondTierBeats,
-        hierarchyLevels,
-        leavesPerBeat,
-      } = this.props
-      let body = null
-      if (orientation === 'horizontal') body = this.renderBeats()
-      else body = this.renderLines()
+    const {
+      orientation,
+      isSmall,
+      timelineViewIsStacked,
+      topTierBeats,
+      secondTierBeats,
+      hierarchyLevels,
+      leavesPerBeat,
+    } = props
+    let body = null
+    if (orientation === 'horizontal') body = renderBeats()
+    else body = renderLines()
 
-      if (isSmall) {
+    if (isSmall) {
+      return (
+        <thead>
+          <tr>
+            <th></th>
+            {body}
+          </tr>
+        </thead>
+      )
+    } else {
+      if (timelineViewIsStacked) {
+        const { x, y } = mouseXY
         return (
-          <thead>
-            <tr>
-              <th></th>
-              {body}
-            </tr>
-          </thead>
-        )
-      } else {
-        if (timelineViewIsStacked) {
-          return [
-            topTierBeats.length ? (
-              <Row key="3rd-level-row">
-                {this.renderTieredBeats(topTierBeats, leavesPerBeat, hierarchyLevels[0])}
-              </Row>
-            ) : null,
-            secondTierBeats.length ? (
-              <Row key="2nd-level-row">
-                {this.renderTieredBeats(secondTierBeats, leavesPerBeat, hierarchyLevels[0])}
-              </Row>
+          <MousePositionContext.Provider x={x} y={y}>
+            [topTierBeats.length ? (
+            <Row key="3rd-level-row">
+              {renderTieredBeats(topTierBeats, leavesPerBeat, hierarchyLevels[0])}
+            </Row>
+            ) : null, secondTierBeats.length ? (
+            <Row key="2nd-level-row">
+              {renderTieredBeats(secondTierBeats, leavesPerBeat, hierarchyLevels[0])}
+            </Row>
             ) : null,
             <Row id="table-beat-row" key="beats-title-row">
               {body}
-            </Row>,
-          ]
-        }
-
-        return <Row id="table-beat-row">{body}</Row>
+            </Row>
+            ]
+          </MousePositionContext.Provider>
+        )
       }
+
+      return <Row id="table-beat-row">{body}</Row>
     }
   }
 

--- a/lib/plottr_components/src/components/timeline/TopRow.js
+++ b/lib/plottr_components/src/components/timeline/TopRow.js
@@ -335,7 +335,7 @@ const TopRowConnector = (connector) => {
           return [
             isLarge ? <Cell key={`place-holder${index}`} /> : null,
             <BeatHeadingCell
-              key={`beatId-${beat.id || index}`}
+              key={`beatId-${beat.id || 'idx-' + index}`}
               span={beatLeaves}
               beatId={beat.id}
             />,

--- a/lib/plottr_components/src/components/timeline/TopRow.js
+++ b/lib/plottr_components/src/components/timeline/TopRow.js
@@ -36,14 +36,21 @@ const TopRowConnector = (connector) => {
       if (firstCell.current) {
         firstCell.current.style.zIndex = 101
       }
+      let lastMoveTimeout = null
       const mouseMoveListener = document.addEventListener('mousemove', (event) => {
-        setMouseXY({
-          x: event.pageX,
-          y: event.pageY,
-        })
+        if (lastMoveTimeout) {
+          clearTimeout(lastMoveTimeout)
+        }
+        lastMoveTimeout = setTimeout(() => {
+          setMouseXY({
+            x: event.pageX,
+            y: event.pageY,
+          })
+        }, 50)
       })
       return () => {
         document.removeEventListener('mousemove', mouseMoveListener)
+        clearTimeout(lastMoveTimeout)
       }
     }, [])
 
@@ -327,7 +334,11 @@ const TopRowConnector = (connector) => {
           const beatLeaves = leavesPerBeat.get(beat.id)
           return [
             isLarge ? <Cell key={`place-holder${index}`} /> : null,
-            <BeatHeadingCell key={`beatId-${beat.id}`} span={beatLeaves} beatId={beat.id} />,
+            <BeatHeadingCell
+              key={`beatId-${beat.id || index}`}
+              span={beatLeaves}
+              beatId={beat.id}
+            />,
             ...renderPaddingCells(beat.id, beatLeaves - 1),
           ]
         }),
@@ -358,22 +369,23 @@ const TopRowConnector = (connector) => {
       )
     } else {
       if (timelineViewIsStacked) {
-        const { x, y } = mouseXY
         return (
-          <MousePositionContext.Provider x={x} y={y}>
-            [topTierBeats.length ? (
-            <Row key="3rd-level-row">
-              {renderTieredBeats(topTierBeats, leavesPerBeat, hierarchyLevels[0])}
-            </Row>
-            ) : null, secondTierBeats.length ? (
-            <Row key="2nd-level-row">
-              {renderTieredBeats(secondTierBeats, leavesPerBeat, hierarchyLevels[0])}
-            </Row>
-            ) : null,
-            <Row id="table-beat-row" key="beats-title-row">
-              {body}
-            </Row>
-            ]
+          <MousePositionContext.Provider value={mouseXY}>
+            {[
+              topTierBeats.length ? (
+                <Row key="3rd-level-row">
+                  {renderTieredBeats(topTierBeats, leavesPerBeat, hierarchyLevels[0])}
+                </Row>
+              ) : null,
+              secondTierBeats.length ? (
+                <Row key="2nd-level-row">
+                  {renderTieredBeats(secondTierBeats, leavesPerBeat, hierarchyLevels[0])}
+                </Row>
+              ) : null,
+              <Row id="table-beat-row" key="beats-title-row">
+                {body}
+              </Row>,
+            ]}
           </MousePositionContext.Provider>
         )
       }

--- a/lib/plottr_components/src/css/beat_block.scss
+++ b/lib/plottr_components/src/css/beat_block.scss
@@ -176,6 +176,10 @@ $medium_width: 80px;
     height: 50px;
     margin: 5px 2px;
   }
+  &.insert-beat {
+    height: 50px;
+    margin: 5px 2px;
+  }
   .insert-beat-wrapper {
     .glyphicon {
       margin-top: -1px;
@@ -210,9 +214,6 @@ $medium_width: 80px;
     height: 100%;
     color: $blue-5;
     border: 3px dashed $blue-5;
-  }
-  &.medium-timeline {
-    height: 123px;
   }
 }
 

--- a/lib/plottr_components/src/css/beat_block.scss
+++ b/lib/plottr_components/src/css/beat_block.scss
@@ -203,16 +203,11 @@ $medium_width: 80px;
     }
   }
   .insert-missing-beat-wrapper.insert-beat {
-    &.large-timeline {
-      padding: 25px 76px;
-      margin-top: 24px;
-      margin-bottom: 24px;
-    }
-    &.medium-timeline {
-      margin-top: 10px;
-      margin-right: 0px;
-      padding: 14px 35px;
-    }
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
     color: $blue-5;
     border: 3px dashed $blue-5;
   }


### PR DESCRIPTION
# Motivation
The stacked view has no way to add or delete the top or second tiers.

# Approach
This PR adds hover controls to the top and second-tier beats for adding and deleting beat headings.
It extends the Plottr floater with:
 - arbitrary placement of floaters, and
 - alignment of floaters
to achieve this.

This PR also adds a mouse position context to the `TopRow` so we can perform complex calculations on whether a beat heading is hovered over.
This complicated logic is necessary because we used overflow visible to create merged cells for the stacked view.

# Demo

https://user-images.githubusercontent.com/1457336/180188491-04cf1186-a5c8-4165-be9f-e44199bc5b4d.mp4

