### PR TITLE
Export new character attributes, disable busy logo & reduce pressure saving templates

### DIFF
--- a/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/__tests__/characters.test.js
+++ b/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/__tests__/characters.test.js
@@ -5,10 +5,10 @@ import { headingTwo, paragraph } from 'components/__fixtures__'
 import default_config from '../../../../default_config'
 
 describe('exportCharacters', () => {
-  let documentContents = {}
   beforeEach(() => resetId())
 
   it('exports characters binder from state', () => {
+    const documentContents = {}
     const binderItem = exportCharacters(state, documentContents, default_config.scrivener)
     // there are 2 characters in the test state but the second one is part of book 2
     // so it shouldn't show up here
@@ -35,6 +35,13 @@ describe('exportCharacters', () => {
   })
 
   it('exports the documentContents', () => {
+    const documentContents = {}
+    const _binderItem = exportCharacters(state, documentContents, default_config.scrivener)
+    // NOTE: description and notes are no longer in this test because
+    // we changed how descriptions and notes are exported per book
+    // with the new feature.  The root-level legacy attributes only
+    // apply to the 'all'/'series' book.  We're exporting book one
+    // here.
     expect(documentContents).toEqual({
       4: {
         body: {
@@ -42,10 +49,6 @@ describe('exportCharacters', () => {
           description: [
             headingTwo('age'),
             paragraph('50s'),
-            headingTwo('Description'),
-            paragraph(`He's a character`),
-            headingTwo('Notes'),
-            paragraph(`He's a character`),
             headingTwo('stuff'),
             paragraph('something'),
             headingTwo('An attribute'),

--- a/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/characters.js
+++ b/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/characters.js
@@ -32,8 +32,15 @@ export default function exportCharacters(state, documentContents, options) {
       categoryId,
       tags,
       templates,
-      ...characterProperties
+      ...remainingCharacterProperties
     } = character
+    const attributes = selectors.characterAttributesSelector(state, characterId, bookToExport)
+    const characterProperties = attributes.reduce((acc, next) => {
+      return {
+        ...acc,
+        [next.name]: next.value,
+      }
+    }, remainingCharacterProperties)
     const { id, binderItem: characterBinderItem } = createTextBinderItem(name)
     binderItem.Children.BinderItem.push(characterBinderItem)
 

--- a/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/characters.js
+++ b/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/characters.js
@@ -8,11 +8,12 @@ import {
 } from '../utils'
 import { selectors } from 'pltr/v2'
 
-const { characterCategoriesSelector, charactersSortedInBookSelector } = selectors
+const { characterCategoriesSelector } = selectors
 
 export default function exportCharacters(state, documentContents, options) {
   const { binderItem } = createFolderBinderItem(i18n('Characters'))
-  const characters = charactersSortedInBookSelector(state)
+  const bookToExport = selectors.currentTimelineSelector(state)
+  const characters = selectors.allDisplayedCharactersSelector(state, null, bookToExport)
   const allCharacterCategories = Object.values(characterCategoriesSelector(state))
   characters.forEach((character) => {
     const {

--- a/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/characters.js
+++ b/lib/plottr_import_export/src/exporter/scrivener/v2/exporters/characters.js
@@ -13,7 +13,11 @@ const { characterCategoriesSelector } = selectors
 export default function exportCharacters(state, documentContents, options) {
   const { binderItem } = createFolderBinderItem(i18n('Characters'))
   const bookToExport = selectors.currentTimelineSelector(state)
-  const characters = selectors.allDisplayedCharactersSelector(state, null, bookToExport)
+  const characters = selectors.allDisplayedCharactersForCurrentBookSelector(
+    state,
+    null,
+    bookToExport
+  )
   const allCharacterCategories = Object.values(characterCategoriesSelector(state))
   characters.forEach((character) => {
     const {

--- a/lib/plottr_import_export/src/exporter/word/exporters/characters.js
+++ b/lib/plottr_import_export/src/exporter/word/exporters/characters.js
@@ -22,7 +22,11 @@ export default function exportCharacters(state, options) {
   }
 
   const bookToExport = selectors.currentTimelineSelector(state)
-  const allCharacters = selectors.allDisplayedCharactersSelector(state, null, bookToExport)
+  const allCharacters = selectors.allDisplayedCharactersForCurrentBookSelector(
+    state,
+    null,
+    bookToExport
+  )
   const attributesSelector = (characterId) =>
     selectors.characterAttributesSelector(state, characterId, bookToExport)
   const images = selectors.imagesSelector(state)

--- a/lib/plottr_import_export/src/exporter/word/exporters/characters.js
+++ b/lib/plottr_import_export/src/exporter/word/exporters/characters.js
@@ -2,7 +2,6 @@ import { t } from 'plottr_locales'
 import { Paragraph, AlignmentType, HeadingLevel, ImageRun } from 'docx'
 import { selectors } from 'pltr/v2'
 
-import exportCustomAttributes from './customAttributes'
 import exportItemTemplates from './itemTemplates'
 import { serialize } from './to_word'
 
@@ -22,10 +21,16 @@ export default function exportCharacters(state, options) {
     )
   }
 
+  const bookToExport = selectors.currentTimelineSelector(state)
+  const allCharacters = selectors.allDisplayedCharactersSelector(state, null, bookToExport)
+  const attributesSelector = (characterId) =>
+    selectors.characterAttributesSelector(state, characterId, bookToExport)
+  const images = selectors.imagesSelector(state)
+
   const paragraphs = characters(
-    state.characters,
-    state.customAttributes['characters'],
-    state.images,
+    allCharacters,
+    attributesSelector,
+    images,
     options,
     allCharacterCategories
   )
@@ -33,7 +38,21 @@ export default function exportCharacters(state, options) {
   return [{ children: children.concat(paragraphs) }]
 }
 
-function characters(characters, customAttributes, images, options, allCharacterCategories) {
+function exportAttributes(attributes, headingLevel) {
+  return (attributes || []).flatMap((ca) => {
+    let paragraphs = []
+    paragraphs.push(new Paragraph({ text: ca.name, heading: headingLevel }))
+    if (ca.type == 'paragraph') {
+      const attrParagraphs = serialize(ca.value)
+      paragraphs = [...paragraphs, ...attrParagraphs]
+    } else {
+      paragraphs.push(new Paragraph({ text: ca.value }))
+    }
+    return paragraphs
+  })
+}
+
+function characters(characters, attributesSelector, images, options, allCharacterCategories) {
   let paragraphs = []
   characters.forEach((ch) => {
     paragraphs.push(new Paragraph({ text: '' }))
@@ -80,7 +99,7 @@ function characters(characters, customAttributes, images, options, allCharacterC
     if (options.characters.customAttributes) {
       paragraphs = [
         ...paragraphs,
-        ...exportCustomAttributes(ch, customAttributes, HeadingLevel.HEADING_3),
+        ...exportAttributes(attributesSelector(ch.id), HeadingLevel.HEADING_3),
       ]
     }
     if (options.characters.templates) {

--- a/lib/pltr/v2/selectors/attributes.js
+++ b/lib/pltr/v2/selectors/attributes.js
@@ -18,10 +18,14 @@ export const allCharacterAttributesSelector = createSelector(attributesSelector,
   return (attributes && attributes.characters) || []
 })
 
+export const overriddenBookIdSelector = (_state, _characterId, bookId) => bookId
+
 export const characterAttributsForBookByIdSelector = createSelector(
   selectedCharacterAttributeTabSelector,
   characterAttributesForBookSelector,
-  (bookId, attributeDescriptors) => {
+  overriddenBookIdSelector,
+  (selectedBookId, attributeDescriptors, overriddenBookId) => {
+    const bookId = overriddenBookId || selectedBookId
     const currentBookAttributeDescriptors = attributeDescriptors.filter((attribute) => {
       return attribute.bookId === bookId
     })

--- a/lib/pltr/v2/selectors/characters.js
+++ b/lib/pltr/v2/selectors/characters.js
@@ -13,6 +13,7 @@ import {
   attributesSelector,
   characterAttributesForCurrentBookSelector,
   characterAttributsForBookByIdSelector,
+  overriddenBookIdSelector,
 } from './attributes'
 import { allBookIdsSelector } from './books'
 import { showBookTabs } from './attributeTabs'
@@ -110,13 +111,18 @@ export const charactersByCategorySelector = createSelector(allCharactersSelector
   groupBy(characters, 'categoryId')
 )
 
-const allDisplayedCharactersSelector = createSelector(
+export const allDisplayedCharactersSelector = createSelector(
   allCharactersSelector,
   characterAttributeTabSelector,
   characterAttributsForBookByIdSelector,
-  (characters, bookId, currentBookAttributeDescirptorsById) => {
+  overriddenBookIdSelector,
+  (characters, bookId, currentBookAttributeDescirptorsById, overridenBookId) => {
     return characters.map((character) =>
-      displayedSingleCharacter(character, bookId, currentBookAttributeDescirptorsById)
+      displayedSingleCharacter(
+        character,
+        overridenBookId || bookId,
+        currentBookAttributeDescirptorsById
+      )
     )
   }
 )
@@ -296,9 +302,16 @@ export const charactersSortedInBookSelector = createSelector(
 
 const characterCustomAttributes = (state) => state.customAttributes.characters
 
-const combinedAttributesForCharacter = (character, attributes, customAttributes, bookId) => {
+const combinedAttributesForCharacter = (
+  character,
+  attributes,
+  customAttributes,
+  selectedBookId,
+  overridenBookId
+) => {
   const characterBookAttributes = character.attributes || []
   const allAttributes = attributes.characters || []
+  const bookId = overridenBookId || selectedBookId
   const newAttributes = allAttributes
     .filter((bookAttribute) => {
       return (
@@ -346,6 +359,7 @@ export const characterAttributesSelector = createSelector(
   attributesSelector,
   characterCustomAttributes,
   characterAttributeTabSelector,
+  overriddenBookIdSelector,
   combinedAttributesForCharacter
 )
 

--- a/lib/pltr/v2/selectors/characters.js
+++ b/lib/pltr/v2/selectors/characters.js
@@ -127,6 +127,22 @@ export const allDisplayedCharactersSelector = createSelector(
   }
 )
 
+export const allDisplayedCharactersForCurrentBookSelector = createSelector(
+  allDisplayedCharactersSelector,
+  characterAttributeTabSelector,
+  overriddenBookIdSelector,
+  (characters, selectedBookId, overriddenBookId) => {
+    const bookId = overriddenBookId || selectedBookId || 'series'
+    if (bookId === 'all' || bookId === 'series') {
+      return characters
+    }
+
+    return characters.filter((character) => {
+      return character.bookIds.indexOf(bookId) > -1
+    })
+  }
+)
+
 export const displayedCharactersByCategorySelector = createSelector(
   allDisplayedCharactersSelector,
   (characters) => groupBy(characters, 'categoryId')

--- a/main/server/template_fetcher.js
+++ b/main/server/template_fetcher.js
@@ -177,7 +177,12 @@ class TemplateFetcher {
       }
       return Promise.resolve()
     })
-    return Promise.all(templateRequests)
+    return Promise.all(templateRequests).then((templateIdValueObjects) => {
+      const templateStoreObject = templateIdValueObjects.reduce((acc, next) => {
+        return { ...next, ...acc }
+      }, this.templatesStore.get())
+      this.templatesStore.set(templateStoreObject)
+    })
   }
 
   fetchTemplate = (id, url) => {
@@ -194,7 +199,7 @@ class TemplateFetcher {
         return resp.json()
       })
       .then((fetchedTemplate) => {
-        return this.templatesStore.setRawKey(id, fetchedTemplate)
+        return { [id]: fetchedTemplate }
       })
   }
 

--- a/src/app/components/Busy.js
+++ b/src/app/components/Busy.js
@@ -1,13 +1,11 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import { selectors } from 'pltr/v2'
 
 const Busy = ({ applicationIsBusyAndCannotBeQuit }) => {
-  return applicationIsBusyAndCannotBeQuit ? (
-    <img width="50" src="../icons/logo_28_500.png" className="busy" />
-  ) : null
+  // We've decided to disable this component until further notice.
+  return null
 }
 
 Busy.propTypes = {


### PR DESCRIPTION
 # Export new character attributes
Plottr now exports character attributes per book.
It does this using the character selectors that are sensitive to book selections:
 - `characterAttributesSelector`, and
 - `allDisplayedCharactersSelector`.
(The feature added more selectors that are sensitive to the currently selected book, but these are what was needed to make export work.)

# Disable busy logo
We've decided to disable the busy indicator until a subsequent release because we didn't have time to consider how it should look and whether we should have it.
The socket server still tracks whether we're busy and prevents the system from shutting down if we are.

# Reduce pressure on template store
When templates update, the server previously fetched them and tried to update their corresponding records in the store in parallel.
This caused a lot of pressure on the host OS's file system; Windows couldn't take the pressure and regularly truncated the file early.
In this PR, we first fetch all the templates, compute the new store object, and write it all to the store in one operation.
This should greatly reduce the pressure on the file system and reduce the likelihood of errors making their way to support.