### PR TITLE
Fix editing the character attribute metadata in `EditAttribute`

### DIFF
--- a/lib/plottr_components/src/components/EditAttribute.js
+++ b/lib/plottr_components/src/components/EditAttribute.js
@@ -89,7 +89,7 @@ const EditAttributeConnector = (connector) => {
         setEditing(false)
         return false
       }
-      editAttribute(index, { name, type }, { name: newName, type })
+      editAttribute(index, { id, name, type }, { id, name: newName, type })
       setEditing(false)
     }
 


### PR DESCRIPTION
 - Ensure that the id of the attribute is passed along to the renamer.