### PR TITLE
Download images into pro local backups

### DIFF
--- a/src/app/__tests__/save.test.js
+++ b/src/app/__tests__/save.test.js
@@ -557,6 +557,8 @@ describe('saveFile', () => {
   })
 })
 
+const DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE = () => {}
+
 describe('backupFile', () => {
   describe('given a whenClientIsReady that produces a dummy saveBackup', () => {
     describe('and a file that lacks the necessary keys', () => {
@@ -582,6 +584,7 @@ describe('backupFile', () => {
           await backupFile(
             whenClientIsReady,
             backupOnFirebase,
+            DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
             CONSOLE_LOGGER
           )(omit(EMPTY_FILE, 'file'))
         } catch (error) {
@@ -611,7 +614,12 @@ describe('backupFile', () => {
             offlineFileURL: () => Promise.resolve('/offline/'),
           })
         }
-        await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+        await backupFile(
+          whenClientIsReady,
+          backupOnFirebase,
+          DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+          CONSOLE_LOGGER
+        )(state)
         expect(called).toBeFalsy()
         expect(savedOnFirebase).toBeFalsy()
       })
@@ -637,7 +645,12 @@ describe('backupFile', () => {
                 offlineFileURL: () => Promise.resolve('/offline/'),
               })
             }
-            await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+            await backupFile(
+              whenClientIsReady,
+              backupOnFirebase,
+              DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+              CONSOLE_LOGGER
+            )(state)
             expect(called).toBeFalsy()
             expect(savedOnFirebase).toBeFalsy()
           })
@@ -661,7 +674,12 @@ describe('backupFile', () => {
                 offlineFileURL: () => Promise.resolve('/offline/'),
               })
             }
-            await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+            await backupFile(
+              whenClientIsReady,
+              backupOnFirebase,
+              DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+              CONSOLE_LOGGER
+            )(state)
             expect(called).toBeFalsy()
             expect(savedOnFirebase).toBeFalsy()
           })
@@ -688,7 +706,12 @@ describe('backupFile', () => {
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+              await backupFile(
+                whenClientIsReady,
+                backupOnFirebase,
+                DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+                CONSOLE_LOGGER
+              )(state)
               expect(called).toBeFalsy()
               expect(savedOnFirebase).toBeTruthy()
             })
@@ -712,7 +735,12 @@ describe('backupFile', () => {
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+              await backupFile(
+                whenClientIsReady,
+                backupOnFirebase,
+                DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+                CONSOLE_LOGGER
+              )(state)
               expect(called).toBeTruthy()
               expect(savedOnFirebase).toBeTruthy()
             })
@@ -738,7 +766,12 @@ describe('backupFile', () => {
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+              await backupFile(
+                whenClientIsReady,
+                backupOnFirebase,
+                DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+                CONSOLE_LOGGER
+              )(state)
               expect(called).toBeFalsy()
               expect(savedOnFirebase).toBeTruthy()
             })
@@ -762,7 +795,12 @@ describe('backupFile', () => {
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+              await backupFile(
+                whenClientIsReady,
+                backupOnFirebase,
+                DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+                CONSOLE_LOGGER
+              )(state)
               expect(called).toBeTruthy()
               expect(savedOnFirebase).toBeTruthy()
             })
@@ -790,7 +828,12 @@ describe('backupFile', () => {
               offlineFileURL: () => Promise.resolve('/offline/'),
             })
           }
-          await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+          await backupFile(
+            whenClientIsReady,
+            backupOnFirebase,
+            DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+            CONSOLE_LOGGER
+          )(state)
           expect(called).toBeFalsy()
           expect(savedOnFirebase).toBeFalsy()
         })
@@ -814,7 +857,12 @@ describe('backupFile', () => {
               offlineFileURL: () => Promise.resolve('/offline/'),
             })
           }
-          await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+          await backupFile(
+            whenClientIsReady,
+            backupOnFirebase,
+            DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+            CONSOLE_LOGGER
+          )(state)
           expect(called).toBeFalsy()
           expect(savedOnFirebase).toBeFalsy()
         })
@@ -838,7 +886,12 @@ describe('backupFile', () => {
               offlineFileURL: () => Promise.resolve('/offline/'),
             })
           }
-          await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
+          await backupFile(
+            whenClientIsReady,
+            backupOnFirebase,
+            DUMMY_DOWNLOAD_IMAGE_FROM_STORAGE,
+            CONSOLE_LOGGER
+          )(state)
           expect(called).toBeTruthy()
           expect(savedOnFirebase).toBeFalsy()
         })

--- a/src/app/__tests__/save.test.js
+++ b/src/app/__tests__/save.test.js
@@ -566,6 +566,11 @@ describe('backupFile', () => {
           called = true
           return Promise.resolve()
         }
+        let savedOnFirebase = false
+        const backupOnFirebase = () => {
+          savedOnFirebase = true
+          return Promise.resolve()
+        }
         const whenClientIsReady = (f) => {
           return f({
             saveBackup: _backupFile,
@@ -574,11 +579,16 @@ describe('backupFile', () => {
         }
         let threw = false
         try {
-          await backupFile(whenClientIsReady, CONSOLE_LOGGER)(omit(EMPTY_FILE, 'file'))
+          await backupFile(
+            whenClientIsReady,
+            backupOnFirebase,
+            CONSOLE_LOGGER
+          )(omit(EMPTY_FILE, 'file'))
         } catch (error) {
           threw = true
           expect(called).toBeFalsy()
         }
+        expect(savedOnFirebase).toBeFalsy()
         expect(threw).toBeTruthy()
       })
     })
@@ -590,14 +600,20 @@ describe('backupFile', () => {
           called = true
           return Promise.resolve()
         }
+        let savedOnFirebase = false
+        const backupOnFirebase = () => {
+          savedOnFirebase = true
+          return Promise.resolve()
+        }
         const whenClientIsReady = (f) => {
           return f({
             saveBackup: _backupFile,
             offlineFileURL: () => Promise.resolve('/offline/'),
           })
         }
-        await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+        await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
         expect(called).toBeFalsy()
+        expect(savedOnFirebase).toBeFalsy()
       })
     })
     describe('given a file with a URL that points to Plottr cloud', () => {
@@ -610,14 +626,20 @@ describe('backupFile', () => {
               called = true
               return Promise.resolve()
             }
+            let savedOnFirebase = false
+            const backupOnFirebase = () => {
+              savedOnFirebase = true
+              return Promise.resolve()
+            }
             const whenClientIsReady = (f) => {
               return f({
                 saveBackup: _backupFile,
                 offlineFileURL: () => Promise.resolve('/offline/'),
               })
             }
-            await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+            await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
             expect(called).toBeFalsy()
+            expect(savedOnFirebase).toBeFalsy()
           })
         })
         describe('with offline mode enabled', () => {
@@ -628,14 +650,20 @@ describe('backupFile', () => {
               called = true
               return Promise.resolve()
             }
+            let savedOnFirebase = false
+            const backupOnFirebase = () => {
+              savedOnFirebase = true
+              return Promise.resolve()
+            }
             const whenClientIsReady = (f) => {
               return f({
                 saveBackup: _backupFile,
                 offlineFileURL: () => Promise.resolve('/offline/'),
               })
             }
-            await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+            await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
             expect(called).toBeFalsy()
+            expect(savedOnFirebase).toBeFalsy()
           })
         })
       })
@@ -649,14 +677,20 @@ describe('backupFile', () => {
                 called = true
                 return Promise.resolve()
               }
+              let savedOnFirebase = false
+              const backupOnFirebase = () => {
+                savedOnFirebase = true
+                return Promise.resolve()
+              }
               const whenClientIsReady = (f) => {
                 return f({
                   saveBackup: _backupFile,
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
               expect(called).toBeFalsy()
+              expect(savedOnFirebase).toBeTruthy()
             })
           })
           describe('and local backups is enabled', () => {
@@ -667,14 +701,20 @@ describe('backupFile', () => {
                 called = true
                 return Promise.resolve()
               }
+              let savedOnFirebase = false
+              const backupOnFirebase = () => {
+                savedOnFirebase = true
+                return Promise.resolve()
+              }
               const whenClientIsReady = (f) => {
                 return f({
                   saveBackup: _backupFile,
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
               expect(called).toBeTruthy()
+              expect(savedOnFirebase).toBeTruthy()
             })
           })
         })
@@ -687,14 +727,20 @@ describe('backupFile', () => {
                 called = true
                 return Promise.resolve()
               }
+              let savedOnFirebase = false
+              const backupOnFirebase = () => {
+                savedOnFirebase = true
+                return Promise.resolve()
+              }
               const whenClientIsReady = (f) => {
                 return f({
                   saveBackup: _backupFile,
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
               expect(called).toBeFalsy()
+              expect(savedOnFirebase).toBeTruthy()
             })
           })
           describe('and local backups is enabled', () => {
@@ -705,14 +751,20 @@ describe('backupFile', () => {
                 called = true
                 return Promise.resolve()
               }
+              let savedOnFirebase = false
+              const backupOnFirebase = () => {
+                savedOnFirebase = true
+                return Promise.resolve()
+              }
               const whenClientIsReady = (f) => {
                 return f({
                   saveBackup: _backupFile,
                   offlineFileURL: () => Promise.resolve('/offline/'),
                 })
               }
-              await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+              await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
               expect(called).toBeTruthy()
+              expect(savedOnFirebase).toBeTruthy()
             })
           })
         })
@@ -727,14 +779,20 @@ describe('backupFile', () => {
             called = true
             return Promise.resolve()
           }
+          let savedOnFirebase = false
+          const backupOnFirebase = () => {
+            savedOnFirebase = true
+            return Promise.resolve()
+          }
           const whenClientIsReady = (f) => {
             return f({
               saveBackup: _backupFile,
               offlineFileURL: () => Promise.resolve('/offline/'),
             })
           }
-          await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+          await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
           expect(called).toBeFalsy()
+          expect(savedOnFirebase).toBeFalsy()
         })
       })
       describe('and backups are disabeld', () => {
@@ -745,14 +803,20 @@ describe('backupFile', () => {
             called = true
             return Promise.resolve()
           }
+          let savedOnFirebase = false
+          const backupOnFirebase = () => {
+            savedOnFirebase = true
+            return Promise.resolve()
+          }
           const whenClientIsReady = (f) => {
             return f({
               saveBackup: _backupFile,
               offlineFileURL: () => Promise.resolve('/offline/'),
             })
           }
-          await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+          await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
           expect(called).toBeFalsy()
+          expect(savedOnFirebase).toBeFalsy()
         })
       })
       describe('and backups are enabled', () => {
@@ -763,14 +827,20 @@ describe('backupFile', () => {
             called = true
             return Promise.resolve()
           }
+          let savedOnFirebase = false
+          const backupOnFirebase = () => {
+            savedOnFirebase = true
+            return Promise.resolve()
+          }
           const whenClientIsReady = (f) => {
             return f({
               saveBackup: _backupFile,
               offlineFileURL: () => Promise.resolve('/offline/'),
             })
           }
-          await backupFile(whenClientIsReady, CONSOLE_LOGGER)(state)
+          await backupFile(whenClientIsReady, backupOnFirebase, CONSOLE_LOGGER)(state)
           expect(called).toBeTruthy()
+          expect(savedOnFirebase).toBeFalsy()
         })
       })
     })

--- a/src/app/bootFile.js
+++ b/src/app/bootFile.js
@@ -12,7 +12,12 @@ import {
   emptyFile,
 } from 'pltr/v2'
 import { t } from 'plottr_locales'
-import { currentUser, initialFetch, overwriteAllKeys } from 'wired-up-firebase'
+import {
+  currentUser,
+  initialFetch,
+  overwriteAllKeys,
+  saveBackup as saveBackupOnFirebase,
+} from 'wired-up-firebase'
 
 import { makeFileSystemAPIs } from '../api'
 import { dispatchingToStore, makeFlagConsistent } from './makeFlagConsistent'
@@ -458,7 +463,7 @@ export function bootFile(
         return store.getState().present
       },
       saveFile(whenClientIsReady, logger),
-      backupFile(whenClientIsReady, logger),
+      backupFile(whenClientIsReady, saveBackupOnFirebase, logger),
       logger,
       SAVE_INTERVAL_MS,
       BACKUP_INTERVAL_MS,

--- a/src/app/bootFile.js
+++ b/src/app/bootFile.js
@@ -18,6 +18,7 @@ import {
   overwriteAllKeys,
   saveBackup as saveBackupOnFirebase,
 } from 'wired-up-firebase'
+import { exportToSelfContainedPlottrFile } from 'plottr_import_export'
 
 import { makeFileSystemAPIs } from '../api'
 import { dispatchingToStore, makeFlagConsistent } from './makeFlagConsistent'
@@ -32,6 +33,7 @@ import { makeFileModule } from './files'
 import { offlineFileURL } from '../common/utils/files'
 import Saver from './saver'
 import { saveFile, backupFile } from './save'
+import { downloadStorageImage } from '../common/downloadStorageImage'
 
 const clientId = machineIdSync()
 
@@ -270,7 +272,11 @@ export function bootFile(
 
   const afterLoading = (userId, saveBackup) => (json) => {
     logger.info(`Loaded file ${json.file.fileName}.`)
-    saveBackup(`${json.file.fileName}.pltr`, json)
+    exportToSelfContainedPlottrFile(json, userId, downloadStorageImage).then(
+      (selfContainedFile) => {
+        saveBackup(`${json.file.fileName}.pltr`, selfContainedFile)
+      }
+    )
   }
 
   const makeFlagsConsistent = (beatHierarchy) => (json) => {

--- a/src/app/save.js
+++ b/src/app/save.js
@@ -39,16 +39,18 @@ export const saveFile = (whenClientIsReady, logger) => (state) => {
 }
 
 export const backupFile = (whenClientIsReady, saveBackupOnFirebase, logger) => (state) => {
+  const isOffline = selectors.isOfflineSelector(state)
   const isCloudFile = selectors.isCloudFileSelector(state)
   const backupEnabled = selectors.backupEnabledSelector(state)
   const userId = selectors.userIdSelector(state)
 
   if (!backupEnabled) return Promise.resolve()
 
-  const cloudBackup = isCloudFile ? saveBackupOnFirebase(userId, state) : Promise.resolve()
+  const cloudBackup =
+    !isOffline && isCloudFile ? saveBackupOnFirebase(userId, state) : Promise.resolve()
 
   return cloudBackup.then(() => {
-    whenClientIsReady(({ saveBackup, offlineFileURL }) => {
+    return whenClientIsReady(({ saveBackup, offlineFileURL }) => {
       const hasAllKeys = selectors.hasAllKeysSelector(state)
       if (!hasAllKeys) {
         const withoutSystemKeys = difference(Object.keys(state), SYSTEM_REDUCER_KEYS)

--- a/src/app/save.js
+++ b/src/app/save.js
@@ -78,7 +78,10 @@ export const backupFile = (whenClientIsReady, saveBackupOnFirebase, logger) => (
           : Promise.resolve(state)
 
         return stateToSave.then((selfContainedFile) => {
-          return saveBackup(helpers.file.withoutProtocol(fileURL), selfContainedFile)
+          const filePath = isCloudFile
+            ? `${selfContainedFile.file.fileName}.pltr`
+            : helpers.file.withoutProtocol(fileURL)
+          return saveBackup(filePath, selfContainedFile)
         })
       })
     })

--- a/src/common/__tests__/downloadStorageImage.test.js
+++ b/src/common/__tests__/downloadStorageImage.test.js
@@ -1,0 +1,67 @@
+import { makeCachedDownloadStorageImage } from '../downloadStorageImage'
+
+describe('makeCachedDownloadStorageImage', () => {
+  describe('given a dummmy downloadStorageImage', () => {
+    describe('that always returns the url as the result', () => {
+      describe('given the same url twice', () => {
+        it('should only call the dummy function once', async () => {
+          let called = 0
+          const dummyDownloadStorageImage = (storageURL, fileId, userId) => {
+            called++
+            return Promise.resolve(storageURL)
+          }
+          const cachedDownloadStorageImage =
+            makeCachedDownloadStorageImage(dummyDownloadStorageImage)
+          const aURL = 'storage://f32gganote233b2behu/cat.png'
+          const result1 = await cachedDownloadStorageImage.downloadStorageImage(
+            aURL,
+            'dummyid',
+            'dummyid'
+          )
+          expect(result1).toEqual(aURL)
+          const result2 = await cachedDownloadStorageImage.downloadStorageImage(
+            aURL,
+            'dummyid',
+            'dummyid'
+          )
+          expect(result2).toEqual(aURL)
+          expect(called).toEqual(1)
+        })
+      })
+      describe('given the same url twice', () => {
+        describe('and then a different URL', () => {
+          it('should only call the dummy function twice', async () => {
+            let called = 0
+            const dummyDownloadStorageImage = (storageURL, fileId, userId) => {
+              called++
+              return Promise.resolve(storageURL)
+            }
+            const cachedDownloadStorageImage =
+              makeCachedDownloadStorageImage(dummyDownloadStorageImage)
+            const aURL = 'storage://f32gganote233b2behu/cat.png'
+            const result1 = await cachedDownloadStorageImage.downloadStorageImage(
+              aURL,
+              'dummyid',
+              'dummyid'
+            )
+            expect(result1).toEqual(aURL)
+            const result2 = await cachedDownloadStorageImage.downloadStorageImage(
+              aURL,
+              'dummyid',
+              'dummyid'
+            )
+            expect(result2).toEqual(aURL)
+            const anotherURL = 'storage://f32gganote233b2behu/dog.png'
+            const result3 = await cachedDownloadStorageImage.downloadStorageImage(
+              anotherURL,
+              'dummyid',
+              'dummyid'
+            )
+            expect(result3).toEqual(anotherURL)
+            expect(called).toEqual(2)
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/common/downloadStorageImage.js
+++ b/src/common/downloadStorageImage.js
@@ -7,3 +7,26 @@ export const downloadStorageImage = (storageURL, fileId, userId) => {
     })
   })
 }
+
+export const makeCachedDownloadStorageImage = (downloadStorageImage) => {
+  let cache = new Map()
+
+  const purgeCache = () => {
+    cache.clear()
+  }
+  const _downloadStorageItem = (storageURL, fileId, userId) => {
+    if (cache.has(storageURL)) {
+      return Promise.resolve(cache.get(storageURL))
+    }
+
+    return downloadStorageImage(storageURL, fileId, userId).then((result) => {
+      cache.set(storageURL, result)
+      return result
+    })
+  }
+
+  return {
+    purgeCache,
+    downloadStorageImage: _downloadStorageItem,
+  }
+}


### PR DESCRIPTION
 - Re-instate the firebase backup mechanism.
 - Ensure that local backups of pro files have the correct name.
 - Always backup a self-contained version of the plottr file (i.e. download all `storage://` protocol items back into the file before saving it.)