### PR TITLE
allow null and undefined attributes to be filtered

### DIFF
--- a/lib/plottr_components/src/css/filter_list_block.scss
+++ b/lib/plottr_components/src/css/filter_list_block.scss
@@ -30,6 +30,7 @@
       user-select: none;
       padding: 4px 8px;
       max-width: 250px;
+      overflow-wrap: break-word;
     }
     li:hover {
       background-color: $body-background-color;

--- a/lib/pltr/v2/selectors/cards.js
+++ b/lib/pltr/v2/selectors/cards.js
@@ -342,7 +342,7 @@ function cardIsVisible(card, filter, filterIsEmpty) {
       if (card[attr] !== undefined) {
         return card[attr] === val
       }
-      if (val === '' && card[attr] === undefined) {
+      if (!val && !card[attr]) {
         return true
       }
       if (attr == 'tag') {


### PR DESCRIPTION
Ticket: https://airtable.com/appfbr7vlSqIfZ9Sn/tblP6AWIpvkOYZ0jR/viwou8K2UyUSkWGts/recrQ5qA0EYCHpnq1?blocks=hide

Also tested on this file: 
[from template proj.pltr.zip](https://github.com/cameronsutter/plottr_electron/files/10346064/from.template.proj.pltr.zip)

Demo

https://user-images.githubusercontent.com/19387007/210612109-a3c31ff3-d5c8-40bf-a0a6-46bbdf3aa6ce.mp4

Latest commit:
I added another fix because i noticed the overflowing text on the filter list

Issue
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/19387007/210704080-008a43ed-265e-48a0-a4e8-4ab1145c4440.png">

Fix
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/19387007/210704009-b79c02b8-9ec5-4a96-8af7-80683b378d1f.png">



