### PR TITLE
Bugfix/popover

### DIFF
--- a/lib/plottr_components/src/components/PlottrFloater.js
+++ b/lib/plottr_components/src/components/PlottrFloater.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { Popover, ArrowContainer } from 'react-tiny-popover'
+import cx from 'classnames'
 
 const PORTAL_ID = 'plottr-floater-portal'
 
@@ -24,7 +25,7 @@ const PlottrFloaterConnector = (connector) => {
     const SuppliedComponent = component
 
     const Component = useCallback(
-      ({ position, childRect, popoverRect }) => {
+      ({ position, childRect, popoverRect, boundaryRect }) => {
         return hideArrow ? (
           <SuppliedComponent />
         ) : (
@@ -35,7 +36,17 @@ const PlottrFloaterConnector = (connector) => {
             arrowColor={darkMode ? '#555' : 'white'}
             arrowSize={10}
             arrowStyle={{}}
-            className="popover-arrow-container"
+            className={cx('popover-arrow-container', {
+              resize:
+                (boundaryRect.height == boundaryRect.bottom &&
+                  boundaryRect.width == boundaryRect.right) ||
+                (boundaryRect.height == boundaryRect.top &&
+                  boundaryRect.width == boundaryRect.right) ||
+                (boundaryRect.height == boundaryRect.bottom &&
+                  boundaryRect.width == boundaryRect.left) ||
+                (boundaryRect.height == boundaryRect.top &&
+                  boundaryRect.width == boundaryRect.left),
+            })}
             arrowClassName="popover-arrow"
           >
             <SuppliedComponent />

--- a/lib/plottr_components/src/css/popover_block.scss
+++ b/lib/plottr_components/src/css/popover_block.scss
@@ -14,8 +14,9 @@
 }
 
 @media (max-width: 800px) {
-  .plottr-popover {
-    max-width: 70vw;
+  .popover-arrow-container.resize {
+    max-height: 70vh;
+    max-width: calc(70vw - 50px);
   }
 }
 

--- a/lib/plottr_components/src/css/popover_block.scss
+++ b/lib/plottr_components/src/css/popover_block.scss
@@ -1,5 +1,5 @@
 .plottr-popover {
-  max-width: 70vw;
+  max-width: 600px;
   max-height: calc(100vh - 35px);
 
   // So reset our font and text properties to avoid inheriting weird values.
@@ -11,6 +11,12 @@
   border-radius: $border-radius-large;
   @include box-shadow(0 5px 10px rgba(0, 0, 0, 0.2));
 
+}
+
+@media (max-width: 800px) {
+  .plottr-popover {
+    max-width: 70vw;
+  }
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
This is the fix for the bug that ryan reported on dev-desktop
@cameronsutter @Quiescent the only case where i noticed that its still cutting the popover is when we hover a mid-position **card** but we can still scroll to view the entire popover content 😅 

Demo

https://user-images.githubusercontent.com/19387007/212068691-8377d30c-a7a3-423f-9170-fe2b2ecf6fd4.mp4

