### PR TITLE
fix typo; use attributes['values']

### DIFF
--- a/lib/plottr_import_export/src/exporter/word/exporters/itemTemplates.js
+++ b/lib/plottr_import_export/src/exporter/word/exporters/itemTemplates.js
@@ -4,7 +4,7 @@ import { serialize } from './to_word'
 
 export default function exportItemTemplates(item, headingLevel) {
   return (item.templates || []).flatMap((t) => {
-    return (t.attributes || []).flatMap((attr) => {
+    return (t.values || []).flatMap((attr) => {
       let paragraphs = []
       if (!attr.value) return []
       paragraphs.push(new Paragraph({ text: attr.name, heading: headingLevel }))


### PR DESCRIPTION
Ticket: https://airtable.com/appfbr7vlSqIfZ9Sn/tblP6AWIpvkOYZ0jR/viwGz7rsWDvln5Ge2/rec8HzeOAghigZ859?blocks=hide